### PR TITLE
[LB-239] Fix ListenBrainz devel environment, add psycopg==2.7.3.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,18 @@ var/
 # Test results
 htmlcov
 .coverage
+
+# Virtualenv
+# http://iamzed.com/2009/05/07/a-primer-on-virtualenv/
+.Python
+[Bb]in
+[Ii]nclude
+[Ll]ib
+[Ll]ib64
+[Ll]ocal
+[Mm]an
+[Ss]cripts
+pyvenv.cfg
+.venv
+pip-selfcheck.json
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ certifi
 redis==2.10.5
 msgpack-python==0.4.8
 requests==2.18.1
+psycopg2==2.7.3.2


### PR DESCRIPTION
# Summary

Specifies `psycopg==2.7.3.2` in the `requirements.txt` because of a [bug](https://github.com/psycopg/psycopg2/issues/594) in psycopg 2.6.1.

# Background

_See [[LB-239]](https://tickets.metabrainz.org/browse/LB-239)._

# Details

I wasn't able to easily test this solution inside of `listenbrainz-server`, so it would be helpful for @mayhem or @paramsingh to look at this one too. It should work in theory, but I also don't want to break something else.

---

_Edit_: Part of the problem is on the first line of the messybrainz-server [`requirements.txt` file](https://github.com/metabrainz/messybrainz-server/blob/master/requirements.txt#L1).