### PR TITLE
BU-2: Allow incrementing integer values in cache

### DIFF
--- a/test/Dockerfile.py3
+++ b/test/Dockerfile.py3
@@ -1,4 +1,4 @@
-FROM metabrainz/python:3.5
+FROM metabrainz/python:3.6
 
 ENV DOCKERIZE_VERSION v0.2.0
 RUN wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \


### PR DESCRIPTION
LB uses this feature a lot to update listen counts of users, so if we want to use brainzutils in LB, this feature is necessary.

In order to implement this, I had to add an option in get and set
that allowed not encoding and decoding the values with msgpack
because msgpack encoded values cannot be incremented.