### PR TITLE
BU-13: Use direct MB database access for artist entity

### DIFF
--- a/brainzutils/musicbrainz_db/artist.py
+++ b/brainzutils/musicbrainz_db/artist.py
@@ -1,8 +1,7 @@
 from collections import defaultdict
 from sqlalchemy.orm import joinedload
 from mbdata import models
-from brainzutils import cache
-from brainzutils.musicbrainz_db import mb_session, DEFAULT_CACHE_EXPIRATION
+from brainzutils.musicbrainz_db import mb_session
 from brainzutils.musicbrainz_db.helpers import get_relationship_info
 from brainzutils.musicbrainz_db.utils import get_entities_by_gids
 from brainzutils.musicbrainz_db.serialize import serialize_artists
@@ -16,11 +15,7 @@ def get_artist_by_id(mbid):
     Returns:
         Dictionary containing the artist information
     """
-    key = cache.gen_key(mbid)
-    artist = cache.get(key)
-    if not artist:
-        artist = _get_artist_by_id(mbid)
-        cache.set(key=key, val=artist, time=DEFAULT_CACHE_EXPIRATION)
+    artist = _get_artist_by_id(mbid)
     return artist
 
 

--- a/brainzutils/musicbrainz_db/artist.py
+++ b/brainzutils/musicbrainz_db/artist.py
@@ -1,0 +1,76 @@
+from collections import defaultdict
+from sqlalchemy.orm import joinedload
+from mbdata import models
+from brainzutils import cache
+from brainzutils.musicbrainz_db import mb_session, DEFAULT_CACHE_EXPIRATION
+from brainzutils.musicbrainz_db.helpers import get_relationship_info
+from brainzutils.musicbrainz_db.utils import get_entities_by_gids
+from brainzutils.musicbrainz_db.serialize import serialize_artists
+from brainzutils.musicbrainz_db.includes import check_includes
+
+
+def get_artist_by_id(mbid):
+    """Get artist with MusicBrainz ID.
+    Args:
+        mbid (uuid): MBID(gid) of the artist.
+    Returns:
+        Dictionary containing the artist information
+    """
+    key = cache.gen_key(mbid)
+    artist = cache.get(key)
+    if not artist:
+        artist = _get_artist_by_id(mbid)
+        cache.set(key=key, val=artist, time=DEFAULT_CACHE_EXPIRATION)
+    return artist
+
+
+def _get_artist_by_id(mbid):
+    return fetch_multiple_artists(
+        [mbid],
+        includes=['artist-rels', 'url-rels'],
+    ).get(mbid)
+
+
+def fetch_multiple_artists(mbids, includes=None):
+    """Get info related to multiple artists using their MusicBrainz IDs.
+    Args:
+        mbids (list): List of MBIDs of artists.
+        includes (list): List of information to be included.
+    Returns:
+        Dictionary containing info of multiple artists keyed by their mbid.
+    """
+    if includes is None:
+        includes = []
+    includes_data = defaultdict(dict)
+    check_includes('artist', includes)
+    with mb_session() as db:
+        query = db.query(models.Artist).\
+                options(joinedload("type"))
+        artists = get_entities_by_gids(
+            query=query,
+            entity_type='artist',
+            mbids=mbids,
+        )
+        artist_ids = [artist.id for artist in artists.values()]
+
+        if 'artist-rels' in includes:
+            get_relationship_info(
+                db=db,
+                target_type='artist',
+                source_type='artist',
+                source_entity_ids=artist_ids,
+                includes_data=includes_data,
+            )
+        if 'url-rels' in includes:
+            get_relationship_info(
+                db=db,
+                target_type='url',
+                source_type='artist',
+                source_entity_ids=artist_ids,
+                includes_data=includes_data,
+            )
+
+    for artist in artists.values():
+        includes_data[artist.id]['type'] = artist.type
+    artists = {str(mbid): serialize_artists(artists[mbid], includes_data[artists[mbid].id]) for mbid in mbids}
+    return artists

--- a/brainzutils/musicbrainz_db/serialize.py
+++ b/brainzutils/musicbrainz_db/serialize.py
@@ -49,3 +49,20 @@ def serialize_recording(recording, includes=None):
         data['isrcs'] = [isrc.isrc for isrc in recording.isrcs]
 
     return data
+
+
+def serialize_artists(artist, includes=None):
+    if includes is None:
+        includes = {}
+    data = {
+        'id': artist.gid,
+        'name': artist.name,
+        'sort_name': artist.sort_name,
+    }
+
+    if 'type' in includes and includes['type']:
+        data['type'] = includes['type'].name
+
+    if 'relationship_objs' in includes:
+        serialize_relationships(data, artist, includes['relationship_objs'])
+    return data

--- a/brainzutils/musicbrainz_db/tests/test_artist.py
+++ b/brainzutils/musicbrainz_db/tests/test_artist.py
@@ -1,0 +1,43 @@
+from unittest import TestCase
+from mock import MagicMock
+from brainzutils.musicbrainz_db.test_data import artist_linkin_park, artist_jay_z
+from brainzutils.musicbrainz_db import artist as mb_artist
+from brainzutils.musicbrainz_db.tests import setup_cache
+
+
+class ArtistTestCase(TestCase):
+
+    def setUp(self):
+        setup_cache()
+        mb_artist.mb_session = MagicMock()
+        self.mock_db = mb_artist.mb_session.return_value.__enter__.return_value
+        self.artist_query = self.mock_db.query.return_value.options.return_value.filter.return_value.all
+
+    def test_get_by_id(self):
+        self.artist_query.return_value = [artist_linkin_park]
+        artist = mb_artist.get_artist_by_id("f59c5520-5f46-4d2c-b2c4-822eabf53419")
+        self.assertDictEqual(artist, {
+            "id": "f59c5520-5f46-4d2c-b2c4-822eabf53419",
+            "name": "Linkin Park",
+            "sort_name": "Linkin Park",
+            "type": "Group"
+        })
+
+    def test_fetch_multiple_artists(self):
+        self.artist_query.return_value = [artist_jay_z, artist_linkin_park]
+        artists = mb_artist.fetch_multiple_artists([
+            "f59c5520-5f46-4d2c-b2c4-822eabf53419",
+            "f82bcf78-5b69-4622-a5ef-73800768d9ac",
+        ])
+        self.assertDictEqual(artists["f82bcf78-5b69-4622-a5ef-73800768d9ac"], {
+            "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
+            "name": "JAY Z",
+            "sort_name": "JAY Z",
+            "type": "Person",
+        })
+        self.assertDictEqual(artists["f59c5520-5f46-4d2c-b2c4-822eabf53419"], {
+            "id": "f59c5520-5f46-4d2c-b2c4-822eabf53419",
+            "name": "Linkin Park",
+            "sort_name": "Linkin Park",
+            "type": "Group",
+        })

--- a/brainzutils/musicbrainz_db/tests/test_artist.py
+++ b/brainzutils/musicbrainz_db/tests/test_artist.py
@@ -2,13 +2,11 @@ from unittest import TestCase
 from mock import MagicMock
 from brainzutils.musicbrainz_db.test_data import artist_linkin_park, artist_jay_z
 from brainzutils.musicbrainz_db import artist as mb_artist
-from brainzutils.musicbrainz_db.tests import setup_cache
 
 
 class ArtistTestCase(TestCase):
 
     def setUp(self):
-        setup_cache()
         mb_artist.mb_session = MagicMock()
         self.mock_db = mb_artist.mb_session.return_value.__enter__.return_value
         self.artist_query = self.mock_db.query.return_value.options.return_value.filter.return_value.all


### PR DESCRIPTION
Add the direct access of MB database for artist entity and add tests too. Contains function for getting `artist` by `mbid` and fetch multiple artists using mbids.