### PR TITLE
 BU-14: Use direct MB database access for release entity

### DIFF
--- a/brainzutils/musicbrainz_db/recording.py
+++ b/brainzutils/musicbrainz_db/recording.py
@@ -1,5 +1,5 @@
-from brainzutils import cache
 from brainzutils.musicbrainz_db import mb_session
+from brainzutils.musicbrainz_db.helpers import get_relationship_info
 from brainzutils.musicbrainz_db.includes import check_includes
 from brainzutils.musicbrainz_db.serialize import serialize_recording
 from brainzutils.musicbrainz_db.utils import get_entities_by_gids
@@ -25,7 +25,7 @@ def get_recording_by_mbid(mbid, includes=None):
 
 def get_many_recordings_by_mbid(mbids, includes=None):
     """ Get multiple recordings with MusicBrainz IDs. It fetches recordings
-        using _fetch_multiple_recordings.
+    using fetch_multiple_recordings.
 
     Args:
         mbids (list): list of uuid (MBID(gid)) of the recordings.
@@ -36,6 +36,7 @@ def get_many_recordings_by_mbid(mbids, includes=None):
     """
     if includes is None:
         includes = []
+
     recordings = _fetch_multiple_recordings(mbids, includes)
 
     return recordings
@@ -49,7 +50,12 @@ def _fetch_multiple_recordings(mbids, includes=None):
         includes (list): List of values to be included.
                         For list of possible values visit https://bitbucket.org/lalinsky/mbdata/wiki/API/v1/includes#!recording
     Returns:
-        Dictionary containing the recordings information with MBIDs as keys.
+        Dictionary containing the recording information with MBIDs as keys.
+            - id: Recording mbid
+            - name: Name of the recording
+            - length: length of the recording
+            - artists:
+                - artist information: id, name, credited_name and join_phrase
     """
     if includes is None:
         includes = []

--- a/brainzutils/musicbrainz_db/release.py
+++ b/brainzutils/musicbrainz_db/release.py
@@ -1,0 +1,106 @@
+from collections import defaultdict
+from mbdata import models
+from sqlalchemy.orm import joinedload
+from brainzutils import cache
+from brainzutils.musicbrainz_db import mb_session, DEFAULT_CACHE_EXPIRATION
+from brainzutils.musicbrainz_db.includes import check_includes
+from brainzutils.musicbrainz_db.serialize import serialize_releases
+from brainzutils.musicbrainz_db.utils import get_entities_by_gids
+from brainzutils.musicbrainz_db.helpers import get_relationship_info
+
+
+def get_release_by_id(mbid):
+    """Get release with the MusicBrainz ID.
+    Args:
+        mbid (uuid): MBID(gid) of the release.
+    Returns:
+        Dictionary containing the release information.
+    """
+    key = cache.gen_key(mbid)
+    release = cache.get(key)
+    if not release:
+        release = _get_release_by_id(mbid)
+        cache.set(key=key, val=release, time=DEFAULT_CACHE_EXPIRATION)
+    return release
+
+
+def _get_release_by_id(mbid):
+    return fetch_multiple_releases(
+        [mbid],
+        includes=['media', 'release-groups'],
+    ).get(mbid)
+
+
+def fetch_multiple_releases(mbids, includes=None):
+    """Get info related to multiple releases using their MusicBrainz IDs.
+    Args:
+        mbids (list): List of MBIDs of releases.
+        includes (list): List of information to be included.
+    Returns:
+        Dictionary containing info of multiple releases keyed by their mbid.
+    """
+    if includes is None:
+        includes = []
+    includes_data = defaultdict(dict)
+    check_includes('release', includes)
+    with mb_session() as db:
+        query = db.query(models.Release)
+        if 'release-groups' in includes:
+            query = query.options(joinedload('release_group'))
+        if 'media' in includes:
+            # Fetch media with tracks
+            query = query.options(joinedload('mediums')).\
+                    options(joinedload('mediums.tracks')).\
+                    options(joinedload('mediums.format')).\
+                    options(joinedload('mediums.tracks.recording'))
+        releases = get_entities_by_gids(
+            query=query,
+            entity_type='release',
+            mbids=mbids,
+        )
+        release_ids = [release.id for release in releases.values()]
+
+        if 'release-groups' in includes:
+            for release in releases.values():
+                includes_data[release.id]['release-groups'] = release.release_group
+
+        if 'media' in includes:
+            for release in releases.values():
+                includes_data[release.id]['media'] = release.mediums
+
+        if 'url-rels' in includes:
+            get_relationship_info(
+                db=db,
+                target_type='url',
+                source_type='release',
+                source_entity_ids=release_ids,
+                includes_data=includes_data,
+            )
+        releases = {str(mbid): serialize_releases(releases[mbid], includes_data[releases[mbid].id]) for mbid in mbids}
+    return releases
+
+
+def browse_releases(release_group_id, includes=None):
+    """Get all the releases by a certain release group.
+    You need to provide the Release Group's MusicBrainz ID.
+    """
+    if includes is None:
+        includes = []
+    with mb_session() as db:
+        release_ids = db.query(models.Release.gid).\
+                      join(models.ReleaseGroup).\
+                      filter(models.ReleaseGroup.gid == release_group_id).all()
+        release_ids = [release_id[0] for release_id in release_ids]
+    releases = fetch_multiple_releases(release_ids, includes=includes)
+    return releases
+
+
+def get_url_rels_from_releases(releases):
+    """Returns all url-rels for a list of releases in a single list (of url-rel dictionaries)
+    Typical usage with browse_releases()
+    """
+    all_url_rels = []
+    for release_gid in releases.keys():
+        if 'url-rels' in releases[release_gid]:
+            all_url_rels.extend([url_rel for url_rel in releases[release_gid]['url-rels']])
+    return all_url_rels

--- a/brainzutils/musicbrainz_db/release.py
+++ b/brainzutils/musicbrainz_db/release.py
@@ -1,8 +1,7 @@
 from collections import defaultdict
 from mbdata import models
 from sqlalchemy.orm import joinedload
-from brainzutils import cache
-from brainzutils.musicbrainz_db import mb_session, DEFAULT_CACHE_EXPIRATION
+from brainzutils.musicbrainz_db import mb_session
 from brainzutils.musicbrainz_db.includes import check_includes
 from brainzutils.musicbrainz_db.serialize import serialize_releases
 from brainzutils.musicbrainz_db.utils import get_entities_by_gids
@@ -16,11 +15,7 @@ def get_release_by_id(mbid):
     Returns:
         Dictionary containing the release information.
     """
-    key = cache.gen_key(mbid)
-    release = cache.get(key)
-    if not release:
-        release = _get_release_by_id(mbid)
-        cache.set(key=key, val=release, time=DEFAULT_CACHE_EXPIRATION)
+    release = _get_release_by_id(mbid)
     return release
 
 

--- a/brainzutils/musicbrainz_db/serialize.py
+++ b/brainzutils/musicbrainz_db/serialize.py
@@ -1,4 +1,35 @@
-""" This module tests serialize.py """
+from brainzutils.musicbrainz_db.utils import ENTITY_MODELS
+from mbdata.utils.models import get_link_target
+
+
+def serialize_relationships(data, source_obj, relationship_objs):
+    """Convert relationship objects to dictionaries.
+
+    Args:
+        data (dict): Dictionary containing info of source object.
+        source_obj (mbdata.models): object of source entity.
+        relationship_objs (dict): Dictionary containing list of objects of different relations.
+
+    Returns:
+        Dictionary containing lists of dictionaries of related entities.
+    """
+
+    for entity_type in ENTITY_MODELS:
+        relation = '{0}-rels'.format(entity_type)
+        if relation in relationship_objs:
+            data[relation] = []
+            for obj in relationship_objs[relation]:
+                link_data = {
+                    'type': obj.link.link_type.name,
+                    'type-id': obj.link.link_type.gid,
+                    'begin-year': obj.link.begin_date_year,
+                    'end-year': obj.link.end_date_year,
+                }
+                link_data['direction'] = 'forward' if source_obj.id == obj.entity0_id else 'backward'
+                if obj.link.ended:
+                    link_data['ended'] = True
+                link_data[entity_type] = SERIALIZE_ENTITIES[entity_type](get_link_target(obj, source_obj))
+                data[relation].append(link_data)
 
 
 def serialize_artist_credit(artist_credit):
@@ -65,4 +96,89 @@ def serialize_artists(artist, includes=None):
 
     if 'relationship_objs' in includes:
         serialize_relationships(data, artist, includes['relationship_objs'])
+    return data
+
+
+def serialize_release_groups(release_group, includes=None):
+    if includes is None:
+        includes = {}
+
+    data = {
+        'id': release_group.gid,
+        'title': release_group.name,
+    }
+
+    if 'type' in includes and includes['type']:
+        data['type'] = includes['type'].name
+
+    if 'artist-credit-phrase' in includes:
+        data['artist-credit-phrase'] = includes['artist-credit-phrase']
+
+    if 'meta' in includes and includes['meta'] and includes['meta'].first_release_date_year:
+        data['first-release-year'] = includes['meta'].first_release_date_year
+
+    if 'artist-credit-names' in includes:
+        data['artist-credit'] = [serialize_artist_credit_names(artist_credit_name)
+                                 for artist_credit_name in includes['artist-credit-names']]
+
+    if 'releases' in includes:
+        data['release-list'] = [serialize_releases(release) for release in includes['releases']]
+
+    if 'relationship_objs' in includes:
+        serialize_relationships(data, release_group, includes['relationship_objs'])
+
+    if 'tags' in includes:
+        data['tag-list'] = includes['tags']
+    return data
+
+
+def serialize_medium(medium, includes=None):
+    if includes is None:
+        includes = {}
+    data = {
+        'name': medium.name,
+        'track_count': medium.track_count,
+        'position': medium.position,
+    }
+    if medium.format:
+        data['format'] = medium.format.name
+
+    if 'tracks' in includes and includes['tracks']:
+        data['track-list'] = [serialize_track(track) for track in includes['tracks']]
+    return data
+
+
+def serialize_track(track, includes=None):
+    if includes is None:
+        includes = {}
+    data = {
+        'id': track.gid,
+        'name': track.name,
+        'number': track.number,
+        'position': track.position,
+        'length': track.length,
+        'recording_id': track.recording.gid,
+        'recording_title': track.recording.name,
+    }
+    return data
+
+
+def serialize_releases(release, includes=None):
+    if includes is None:
+        includes = {}
+
+    data = {
+        'id': release.gid,
+        'name': release.name,
+    }
+
+    if 'relationship_objs' in includes:
+        serialize_relationships(data, release, includes['relationship_objs'])
+
+    if 'release-groups' in includes:
+        data['release-group'] = serialize_release_groups(includes['release-groups'])
+
+    if 'media' in includes:
+        data['medium-list'] = [serialize_medium(medium, includes={'tracks': medium.tracks})
+                               for medium in includes['media']]
     return data

--- a/brainzutils/musicbrainz_db/tests/test_release.py
+++ b/brainzutils/musicbrainz_db/tests/test_release.py
@@ -1,6 +1,5 @@
 from unittest import TestCase
 from mock import MagicMock
-# from brainzutils.musicbrainz_db.tests import setup_cache
 from brainzutils.musicbrainz_db.test_data import (
     release_numb_encore,
     release_collision_course,

--- a/brainzutils/musicbrainz_db/tests/test_release.py
+++ b/brainzutils/musicbrainz_db/tests/test_release.py
@@ -1,0 +1,43 @@
+from unittest import TestCase
+from mock import MagicMock
+from brainzutils.musicbrainz_db.tests import setup_cache
+from brainzutils.musicbrainz_db.test_data import (
+    release_numb_encore,
+    release_collision_course,
+    release_numb_encore_1,
+)
+from brainzutils.musicbrainz_db import release as mb_release
+
+
+class ReleaseTestCase(TestCase):
+
+    def setUp(self):
+        setup_cache()
+        mb_release.mb_session = MagicMock()
+        self.mock_db = mb_release.mb_session.return_value.__enter__.return_value
+        self.release_query = self.mock_db.query.return_value.options.return_value.options.return_value.\
+            options.return_value.options.return_value.options.return_value.filter.return_value.all
+
+    def test_get_by_id(self):
+        self.release_query.return_value = [release_numb_encore]
+        release = mb_release.get_release_by_id('16bee711-d7ce-48b0-adf4-51f124bcc0df')
+        self.assertEqual(release["name"], "Numb/Encore")
+        self.assertEqual(len(release["medium-list"][0]["track-list"]), 2)
+        self.assertDictEqual(release["medium-list"][0]["track-list"][0], {
+            "id": "dfe024b2-95b2-453f-b03e-3b9fa06f44e6",
+            "name": "Numb/Encore (explicit)",
+            "number": "1",
+            "position": 1,
+            "length": 207000,
+            "recording_id": "daccb724-8023-432a-854c-e0accb6c8678",
+            "recording_title": "Numb/Encore (explicit)"
+        })
+
+    def test_fetch_multiple_releases(self):
+        self.mock_db.query.return_value.filter.return_value.all.return_value = [release_numb_encore_1, release_collision_course]
+        releases = mb_release.fetch_multiple_releases(
+            mbids=['f51598f5-4ef9-4b8a-865d-06a077bf78cf', 'a64a0467-9d7a-4ffa-90b8-d87d9b41e311'],
+        )
+        self.assertEqual(len(releases), 2)
+        self.assertEqual(releases['a64a0467-9d7a-4ffa-90b8-d87d9b41e311']['name'], 'Numb/Encore')
+        self.assertEqual(releases['f51598f5-4ef9-4b8a-865d-06a077bf78cf']['name'], 'Collision Course')

--- a/brainzutils/musicbrainz_db/tests/test_release.py
+++ b/brainzutils/musicbrainz_db/tests/test_release.py
@@ -1,6 +1,6 @@
 from unittest import TestCase
 from mock import MagicMock
-from brainzutils.musicbrainz_db.tests import setup_cache
+# from brainzutils.musicbrainz_db.tests import setup_cache
 from brainzutils.musicbrainz_db.test_data import (
     release_numb_encore,
     release_collision_course,
@@ -12,7 +12,6 @@ from brainzutils.musicbrainz_db import release as mb_release
 class ReleaseTestCase(TestCase):
 
     def setUp(self):
-        setup_cache()
         mb_release.mb_session = MagicMock()
         self.mock_db = mb_release.mb_session.return_value.__enter__.return_value
         self.release_query = self.mock_db.query.return_value.options.return_value.options.return_value.\

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 Flask==0.12.2
 Flask-DebugToolbar==0.10.1
 Flask-UUID==0.2
-raven[flask]==6.4.0
+raven[flask]==6.6.0
 certifi
 redis==2.10.5
 msgpack-python==0.4.8


### PR DESCRIPTION
Add the direct access of MB database for release entity and add tests as well. Contains function for getting release by mbid, fetch multiple releases using mbids and browse releases.