### PR TITLE
BU-15: Add function to get releases using recording mbid

### DIFF
--- a/brainzutils/musicbrainz_db/release.py
+++ b/brainzutils/musicbrainz_db/release.py
@@ -130,6 +130,6 @@ def get_releases_using_recording_mbid(recording_mbid):
 
         serial_releases = [serialize_releases(release) for release in releases]
         if not serial_releases:
-            raise mb_exceptions.NoDataFoundException("Couldn't find releases.")
+            raise mb_exceptions.NoDataFoundException("Couldn't find release for recording with MBID: %s." % str(recording_mbid))
 
         return serial_releases

--- a/brainzutils/musicbrainz_db/release.py
+++ b/brainzutils/musicbrainz_db/release.py
@@ -106,6 +106,16 @@ def get_url_rels_from_releases(releases):
 def get_releases_using_recording_mbid(recording_mbid):
     """Returns a list of releases that contain the recording with
        the given recording MBID.
+
+       Args:
+           recording_mbid (UUID): recording MBID for which releases are to be fetched.
+
+       Returns:
+           serial_releases (list): list with dictionary elements of following format:
+           {
+               'id': <release MBID>,
+               'name': <release Title>,
+           }
     """
 
     # First fetch the recording so that redirects don't create any problem

--- a/brainzutils/musicbrainz_db/test_data.py
+++ b/brainzutils/musicbrainz_db/test_data.py
@@ -417,3 +417,15 @@ release_collision_course.release_group = releasegroup_collision_course
 release_collision_course.gid = 'f51598f5-4ef9-4b8a-865d-06a077bf78cf'
 release_collision_course.name = 'Collision Course'
 release_collision_course.status = releasestatus_official
+
+release_the_hits_collection_volume_one_1 = Release()
+release_the_hits_collection_volume_one_1.gid = 'f1183a86-36d2-4f1f-ab8f-6f965dc0b033'
+release_the_hits_collection_volume_one_1.name = 'The Hits Collection Volume One'
+
+release_the_hits_collection_volume_one_2 = Release()
+release_the_hits_collection_volume_one_2.gid = '3c535d03-2fcc-467a-8d47-34b3250b8211'
+release_the_hits_collection_volume_one_2.name = 'The Hits Collection Volume One'
+
+release_blueprint = Release()
+release_blueprint.gid = '7111c8bc-8549-4abc-8ab9-db13f65b4a55'
+release_blueprint.name = 'Blueprint 2.1'

--- a/brainzutils/musicbrainz_db/tests/test_release.py
+++ b/brainzutils/musicbrainz_db/tests/test_release.py
@@ -1,9 +1,13 @@
 from unittest import TestCase
 from mock import MagicMock
 from brainzutils.musicbrainz_db.test_data import (
+    recording_numb_encore_explicit,
     release_numb_encore,
     release_collision_course,
     release_numb_encore_1,
+    release_blueprint,
+    release_the_hits_collection_volume_one_1,
+    release_the_hits_collection_volume_one_2
 )
 from brainzutils.musicbrainz_db import release as mb_release
 
@@ -39,3 +43,25 @@ class ReleaseTestCase(TestCase):
         self.assertEqual(len(releases), 2)
         self.assertEqual(releases['a64a0467-9d7a-4ffa-90b8-d87d9b41e311']['name'], 'Numb/Encore')
         self.assertEqual(releases['f51598f5-4ef9-4b8a-865d-06a077bf78cf']['name'], 'Collision Course')
+
+    def test_get_releases_using_recording_mbid(self):
+        """Tests if releases are fetched correctly for a given recording MBID"""
+
+        mb_release.recording = MagicMock()
+        mb_release.recording.query.return_value.options.return_value.options.return_value.\
+        options.return_value.filter.return_value.all.return_value = [recording_numb_encore_explicit]
+
+        self.mock_db.query.return_value.join.return_value.join.return_value.join.return_value.\
+        filter.return_value.all.return_value = [
+            release_the_hits_collection_volume_one_1,
+            release_blueprint,
+            release_the_hits_collection_volume_one_2,
+        ]
+
+        releases = mb_release.get_releases_using_recording_mbid('5465ca86-3881-4349-81b2-6efbd3a59451')
+
+        self.assertListEqual(releases, [
+            {'id': 'f1183a86-36d2-4f1f-ab8f-6f965dc0b033', 'name': 'The Hits Collection Volume One'},
+            {'id': '7111c8bc-8549-4abc-8ab9-db13f65b4a55', 'name': 'Blueprint 2.1'},
+            {'id': '3c535d03-2fcc-467a-8d47-34b3250b8211', 'name': 'The Hits Collection Volume One'},
+        ])

--- a/brainzutils/musicbrainz_db/tests/test_release.py
+++ b/brainzutils/musicbrainz_db/tests/test_release.py
@@ -48,17 +48,24 @@ class ReleaseTestCase(TestCase):
         """Tests if releases are fetched correctly for a given recording MBID"""
 
         mb_release.recording = MagicMock()
-        mb_release.recording.query.return_value.options.return_value.options.return_value.\
-        options.return_value.filter.return_value.all.return_value = [recording_numb_encore_explicit]
+        mb_release.recording.get_recording_by_mbid.return_value = {
+            'id': 'daccb724-8023-432a-854c-e0accb6c8678',
+            'name': 'Numb/Encore (explicit)',
+            'length': 205.28,
+        }
 
-        self.mock_db.query.return_value.join.return_value.join.return_value.join.return_value.\
-        filter.return_value.all.return_value = [
+        release_query = self.mock_db.query.return_value.join.return_value.join.return_value.join.return_value.\
+                        filter.return_value.all
+        release_query.return_value = [
             release_the_hits_collection_volume_one_1,
             release_blueprint,
             release_the_hits_collection_volume_one_2,
         ]
 
         releases = mb_release.get_releases_using_recording_mbid('5465ca86-3881-4349-81b2-6efbd3a59451')
+
+        mb_release.recording.get_recording_by_mbid.assert_called_once_with('5465ca86-3881-4349-81b2-6efbd3a59451')
+        release_query.assert_called_once()
 
         self.assertListEqual(releases, [
             {'id': 'f1183a86-36d2-4f1f-ab8f-6f965dc0b033', 'name': 'The Hits Collection Volume One'},


### PR DESCRIPTION
### Summary
This will be used in MessyBrainz. As we need to create release clusters for the recordings which contain only recording MBID. So, using this functionality we can get releases using recording MBID.
### Action
Created get_releases_using_recording_mbid and wrote tests for the same.