### PR TITLE
Add editor entity and use sqlalchemy-dst to automatically serialize it

### DIFF
--- a/brainzutils/musicbrainz_db/editor.py
+++ b/brainzutils/musicbrainz_db/editor.py
@@ -38,14 +38,13 @@ def fetch_multiple_editors(editor_ids, includes=None):
     includes_data = defaultdict(dict)
     check_includes('editor', includes)
     with mb_session() as db:
-        query = db.query(models.Editor).\
-                options(joinedload("type"))
+        query = db.query(models.Editor)
         editors = get_entities_by_ids(
             query=query,
             entity_type='editor',
             ids=editor_ids,
         )
         editor_ids = [editor.id for editor in editors.values()]
+        editors = {editor_id: serialize_editors(editors[editor_id], includes_data) for editor_id in editor_ids}
 
-    editors = {editor_id: serialize_editors(editors[editor_id], includes_data) for editor_id in editor_ids}
     return editors

--- a/brainzutils/musicbrainz_db/editor.py
+++ b/brainzutils/musicbrainz_db/editor.py
@@ -3,7 +3,7 @@ from sqlalchemy.orm import joinedload
 from mbdata import models
 from brainzutils.musicbrainz_db import mb_session
 from brainzutils.musicbrainz_db.utils import get_entities_by_ids
-from brainzutils.musicbrainz_db.serialize import serialize_editors
+from brainzutils.musicbrainz_db.serialize import serialize_editor
 from brainzutils.musicbrainz_db.includes import check_includes
 
 
@@ -45,6 +45,6 @@ def fetch_multiple_editors(editor_ids, includes=None):
             ids=editor_ids,
         )
         editor_ids = [editor.id for editor in editors.values()]
-        editors = {editor_id: serialize_editors(editors[editor_id], includes_data) for editor_id in editor_ids}
+        editors = {editor_id: serialize_editor(editors[editor_id], includes_data) for editor_id in editor_ids}
 
     return editors

--- a/brainzutils/musicbrainz_db/editor.py
+++ b/brainzutils/musicbrainz_db/editor.py
@@ -1,0 +1,51 @@
+from collections import defaultdict
+from sqlalchemy.orm import joinedload
+from mbdata import models
+from brainzutils.musicbrainz_db import mb_session
+from brainzutils.musicbrainz_db.utils import get_entities_by_ids
+from brainzutils.musicbrainz_db.serialize import serialize_editors
+from brainzutils.musicbrainz_db.includes import check_includes
+
+
+def get_editor_by_id(editor_id):
+    """Get editor with editor ID.
+    Args:
+        editor_id (int): ID of the editor.
+    Returns:
+        Dictionary containing the editor information
+    """
+    editor = _get_editor_by_id(editor_id)
+    return editor
+
+
+def _get_editor_by_id(editor_id):
+    return fetch_multiple_editors(
+        [editor_id],
+        includes=[],
+    ).get(editor_id)
+
+
+def fetch_multiple_editors(editor_ids, includes=None):
+    """Get info related to multiple editors using their editor IDs.
+    Args:
+        editor_ids (list): List of IDs of editors.
+        includes (list): List of information to be included.
+    Returns:
+        Dictionary containing info of multiple editors keyed by their editor_id.
+    """
+    if includes is None:
+        includes = []
+    includes_data = defaultdict(dict)
+    check_includes('editor', includes)
+    with mb_session() as db:
+        query = db.query(models.Editor).\
+                options(joinedload("type"))
+        editors = get_entities_by_ids(
+            query=query,
+            entity_type='editor',
+            ids=editor_ids,
+        )
+        editor_ids = [editor.id for editor in editors.values()]
+
+    editors = {editor_id: serialize_editors(editors[editor_id], includes_data) for editor_id in editor_ids}
+    return editors

--- a/brainzutils/musicbrainz_db/includes.py
+++ b/brainzutils/musicbrainz_db/includes.py
@@ -31,7 +31,7 @@ VALID_INCLUDES = {
         "artists", "labels", "recordings", "release-groups", "media", "annotation", "aliases"
     ] + TAG_INCLUDES + RELATION_INCLUDES,
     'artist': ["recordings", "releases", "media", "aliases", "annotation"] + RELATION_INCLUDES + TAG_INCLUDES,
-    'editor': [],  # TODO: Add editor includes
+    'editor': [],  # TODO: List includes here (BU-18)
 }
 
 

--- a/brainzutils/musicbrainz_db/includes.py
+++ b/brainzutils/musicbrainz_db/includes.py
@@ -31,6 +31,7 @@ VALID_INCLUDES = {
         "artists", "labels", "recordings", "release-groups", "media", "annotation", "aliases"
     ] + TAG_INCLUDES + RELATION_INCLUDES,
     'artist': ["recordings", "releases", "media", "aliases", "annotation"] + RELATION_INCLUDES + TAG_INCLUDES,
+    'editor': [],  # TODO: Add editor includes
 }
 
 

--- a/brainzutils/musicbrainz_db/serialize.py
+++ b/brainzutils/musicbrainz_db/serialize.py
@@ -198,7 +198,7 @@ def serialize_url(url, includes=None):
     return data
 
 
-def serialize_editors(editor, includes=None):
+def serialize_editor(editor, includes=None):
     data = row2dict(editor, exclude_pk=True, exclude={'password', 'ha1'})
 
     # TODO: Add includes to data here (BU-18)
@@ -212,5 +212,5 @@ SERIALIZE_ENTITIES = {
     'release': serialize_releases,
     'medium': serialize_medium,
     'url': serialize_url,
-    'editor': serialize_editors,
+    'editor': serialize_editor,
 }

--- a/brainzutils/musicbrainz_db/serialize.py
+++ b/brainzutils/musicbrainz_db/serialize.py
@@ -201,6 +201,8 @@ def serialize_url(url, includes=None):
 def serialize_editors(editor, includes=None):
     data = row2dict(editor, exclude_pk=True, exclude={'password', 'ha1'})
 
+    # TODO: Add includes to data here (BU-18)
+
     return data
 
 

--- a/brainzutils/musicbrainz_db/serialize.py
+++ b/brainzutils/musicbrainz_db/serialize.py
@@ -1,5 +1,6 @@
 from brainzutils.musicbrainz_db.utils import ENTITY_MODELS
 from mbdata.utils.models import get_link_target
+from sqlalchemy_dst import row2dict
 
 
 def serialize_relationships(data, source_obj, relationship_objs):
@@ -197,10 +198,17 @@ def serialize_url(url, includes=None):
     return data
 
 
+def serialize_editors(editor, includes=None):
+    data = row2dict(editor, exclude_pk=True, exclude={'password', 'ha1'})
+
+    return data
+
+
 SERIALIZE_ENTITIES = {
     'artist': serialize_artists,
     'release_group': serialize_release_groups,
     'release': serialize_releases,
     'medium': serialize_medium,
     'url': serialize_url,
+    'editor': serialize_editors,
 }

--- a/brainzutils/musicbrainz_db/test_data.py
+++ b/brainzutils/musicbrainz_db/test_data.py
@@ -25,6 +25,7 @@ from mbdata.models import (
     Event,
     EventType,
     Track,
+    Editor,
 )
 
 # Place (d71ffe38-5eaf-426b-9a2e-e1f21bc84609) with url-rels, place-rels
@@ -429,3 +430,13 @@ release_the_hits_collection_volume_one_2.name = 'The Hits Collection Volume One'
 release_blueprint = Release()
 release_blueprint.gid = '7111c8bc-8549-4abc-8ab9-db13f65b4a55'
 release_blueprint.name = 'Blueprint 2.1'
+
+editor_dt = datetime.datetime(2014, 12, 1, 14, 6, 42, 321443)
+editor_date = datetime.date(1999, 1, 1)
+
+editor_1 = Editor(id=2323, name="Editor 1", privs=0, member_since=editor_dt, email_confirm_date=editor_dt,
+                  last_login_date=editor_dt, last_updated=editor_dt, deleted=False)
+editor_2 = Editor(id=2324, name="Editor 2", privs=3, email="editor@example.com", website="example.com",
+                  bio="Random\neditor", member_since=editor_dt, email_confirm_date=editor_dt,
+                  last_login_date=editor_dt, last_updated=editor_dt, birth_date=editor_date, deleted=False,
+                  area=area_hameenlinna)

--- a/brainzutils/musicbrainz_db/test_data.py
+++ b/brainzutils/musicbrainz_db/test_data.py
@@ -435,8 +435,10 @@ editor_dt = datetime.datetime(2014, 12, 1, 14, 6, 42, 321443)
 editor_date = datetime.date(1999, 1, 1)
 
 editor_1 = Editor(id=2323, name="Editor 1", privs=0, member_since=editor_dt, email_confirm_date=editor_dt,
-                  last_login_date=editor_dt, last_updated=editor_dt, deleted=False)
+                  last_login_date=editor_dt, last_updated=editor_dt, deleted=False, password="{CLEARTEXT}pass",
+                  ha1="3f3edade87115ce351d63f42d92a1834")
 editor_2 = Editor(id=2324, name="Editor 2", privs=3, email="editor@example.com", website="example.com",
                   bio="Random\neditor", member_since=editor_dt, email_confirm_date=editor_dt,
                   last_login_date=editor_dt, last_updated=editor_dt, birth_date=editor_date, deleted=False,
-                  area=area_hameenlinna)
+                  area=area_hameenlinna, password="$2b$12$2odiKUAGktuwM2J.tp/uZ.54bniapSMjCln3J1TfC6zx74QFuawQ6",
+                  ha1="3f3edade87115ce351d63f42d92a1834")

--- a/brainzutils/musicbrainz_db/tests/test_editor.py
+++ b/brainzutils/musicbrainz_db/tests/test_editor.py
@@ -8,7 +8,7 @@ class EditorTestCase(TestCase):
     def setUp(self):
         mb_editor.mb_session = MagicMock()
         self.mock_db = mb_editor.mb_session.return_value.__enter__.return_value
-        self.editor_query = self.mock_db.query.return_value.options.return_value.filter.return_value.all
+        self.editor_query = self.mock_db.query.return_value.filter.return_value.all
 
         self.editor_1_dict = {
             "id": 2323,

--- a/brainzutils/musicbrainz_db/tests/test_editor.py
+++ b/brainzutils/musicbrainz_db/tests/test_editor.py
@@ -49,7 +49,7 @@ class EditorTestCase(TestCase):
         editor = mb_editor.get_editor_by_id(2323)
         self.assertDictEqual(editor, self.editor_1_dict)
 
-    def test_fetch_multiple_artists(self):
+    def test_fetch_multiple_editors(self):
         self.editor_query.return_value = [editor_1, editor_2]
         editors = mb_editor.fetch_multiple_editors([2323, 2324])
         self.assertDictEqual(editors[2323], self.editor_1_dict)

--- a/brainzutils/musicbrainz_db/tests/test_editor.py
+++ b/brainzutils/musicbrainz_db/tests/test_editor.py
@@ -1,0 +1,56 @@
+from unittest import TestCase
+from mock import MagicMock
+from brainzutils.musicbrainz_db.test_data import editor_dt, editor_date, editor_1, editor_2
+from brainzutils.musicbrainz_db import editor as mb_editor
+
+
+class EditorTestCase(TestCase):
+    def setUp(self):
+        mb_editor.mb_session = MagicMock()
+        self.mock_db = mb_editor.mb_session.return_value.__enter__.return_value
+        self.editor_query = self.mock_db.query.return_value.options.return_value.filter.return_value.all
+
+        self.editor_1_dict = {
+            "id": 2323,
+            "name": "Editor 1",
+            "privs": 0,
+            "email": None,
+            "website": None,
+            "bio": None,
+            "member_since": editor_dt,
+            "email_confirm_date": editor_dt,
+            "last_login_date": editor_dt,
+            "last_updated": editor_dt,
+            "birth_date": None,
+            "deleted": False,
+            "gender": None,
+            "area": None,
+        }
+
+        self.editor_2_dict = {
+            "id": 2324,
+            "name": "Editor 2",
+            "privs": 3,
+            "email": "editor@example.com",
+            "website": "example.com",
+            "bio": "Random\neditor",
+            "member_since": editor_dt,
+            "email_confirm_date": editor_dt,
+            "last_login_date": editor_dt,
+            "last_updated": editor_dt,
+            "birth_date": editor_date,
+            "deleted": False,
+            "gender": None,
+            "area": None,
+        }
+
+    def test_get_by_id(self):
+        self.editor_query.return_value = [editor_1]
+        editor = mb_editor.get_editor_by_id(2323)
+        self.assertDictEqual(editor, self.editor_1_dict)
+
+    def test_fetch_multiple_artists(self):
+        self.editor_query.return_value = [editor_1, editor_2]
+        editors = mb_editor.fetch_multiple_editors([2323, 2324])
+        self.assertDictEqual(editors[2323], self.editor_1_dict)
+        self.assertDictEqual(editors[2324], self.editor_2_dict)

--- a/brainzutils/musicbrainz_db/tests/test_serialize.py
+++ b/brainzutils/musicbrainz_db/tests/test_serialize.py
@@ -1,6 +1,8 @@
-from brainzutils.musicbrainz_db.serialize import serialize_recording, serialize_artist_credit
-from brainzutils.musicbrainz_db.test_data import recording_numb_encore_explicit, artistcredit_jay_z_linkin_park
+from brainzutils.musicbrainz_db.serialize import serialize_recording, serialize_artist_credit, serialize_editor
+from brainzutils.musicbrainz_db.test_data import recording_numb_encore_explicit, artistcredit_jay_z_linkin_park, \
+    editor_2
 from unittest import TestCase
+
 
 class SerializeTestCase(TestCase):
     def test_serialize_recording(self):
@@ -8,49 +10,55 @@ class SerializeTestCase(TestCase):
         # Without any includes
         recording = serialize_recording(recording_numb_encore_explicit)
         self.assertDictEqual(recording,
-            {
-                'length': 205.28,
-                'id': 'daccb724-8023-432a-854c-e0accb6c8678',
-                'name': 'Numb/Encore (explicit)',
-            }
-        )
+                             {
+                                 'length': 205.28,
+                                 'id': 'daccb724-8023-432a-854c-e0accb6c8678',
+                                 'name': 'Numb/Encore (explicit)',
+                             }
+                             )
 
         # With artists included
         recording = serialize_recording(recording_numb_encore_explicit, includes={'artists'})
         self.assertDictEqual(recording,
-            {
-                'id': 'daccb724-8023-432a-854c-e0accb6c8678',
-                'name': 'Numb/Encore (explicit)',
-                'length': 205.28,
-                'artists':[
-                    {
-                        'id': 'f82bcf78-5b69-4622-a5ef-73800768d9ac',
-                        'name': 'JAY Z',
-                        'credited_name': 'Jay-Z',
-                        'join_phrase': '/'
-                    },
-                    {
-                        'id': 'f59c5520-5f46-4d2c-b2c4-822eabf53419',
-                        'name': 'Linkin Park'
-                    }
-                ]
-            }
-        )
+                             {
+                                 'id': 'daccb724-8023-432a-854c-e0accb6c8678',
+                                 'name': 'Numb/Encore (explicit)',
+                                 'length': 205.28,
+                                 'artists': [
+                                     {
+                                         'id': 'f82bcf78-5b69-4622-a5ef-73800768d9ac',
+                                         'name': 'JAY Z',
+                                         'credited_name': 'Jay-Z',
+                                         'join_phrase': '/'
+                                     },
+                                     {
+                                         'id': 'f59c5520-5f46-4d2c-b2c4-822eabf53419',
+                                         'name': 'Linkin Park'
+                                     }
+                                 ]
+                             }
+                             )
 
     def test_serialize_artist_credits(self):
         """Test that artist_credits are serialized properly."""
         artist_credits = serialize_artist_credit(artistcredit_jay_z_linkin_park)
         self.assertListEqual(artist_credits,
-            [
-                {
-                    'id': 'f82bcf78-5b69-4622-a5ef-73800768d9ac',
-                    'name': 'JAY Z',
-                    'credited_name': 'Jay-Z',
-                    'join_phrase': '/'
-                },
-                {
-                    'id': 'f59c5520-5f46-4d2c-b2c4-822eabf53419',
-                    'name': 'Linkin Park'
-                }
-            ]
-        )
+                             [
+                                 {
+                                     'id': 'f82bcf78-5b69-4622-a5ef-73800768d9ac',
+                                     'name': 'JAY Z',
+                                     'credited_name': 'Jay-Z',
+                                     'join_phrase': '/'
+                                 },
+                                 {
+                                     'id': 'f59c5520-5f46-4d2c-b2c4-822eabf53419',
+                                     'name': 'Linkin Park'
+                                 }
+                             ]
+                             )
+
+    def test_serialize_editor(self):
+        """Test that sensitive information is removed, everything else is covered in test_editor."""
+        editor = serialize_editor(editor_2)
+        self.assertNotIn("password", editor)
+        self.assertNotIn("ha1", editor)

--- a/brainzutils/musicbrainz_db/utils.py
+++ b/brainzutils/musicbrainz_db/utils.py
@@ -77,7 +77,7 @@ def get_entities_by_ids(query, entity_type, ids):
         Dictionary of objects of target entities keyed by their ID.
     """
     entity_model = ENTITY_MODELS[entity_type]
-    results = query.filter(entity_model.id in ids).all()
+    results = query.filter(entity_model.id.in_(ids)).all()
     remaining_ids = list(set(ids) - {entity.id for entity in results})
     entities = {entity.id: entity for entity in results}
 

--- a/brainzutils/musicbrainz_db/utils.py
+++ b/brainzutils/musicbrainz_db/utils.py
@@ -11,7 +11,8 @@ ENTITY_MODELS = {
     'event': models.Event,
     'series': models.Series,
     'url': models.URL,
-    'recording':models.Recording,
+    'recording': models.Recording,
+    'editor': models.Editor,
 }
 
 
@@ -58,4 +59,30 @@ def get_entities_by_gids(query, entity_type, mbids):
     if remaining_gids:
         raise mb_exceptions.NoDataFoundException("Couldn't find entities with IDs: {mbids}".format(mbids=remaining_gids))
     
+    return entities
+
+
+def get_entities_by_ids(query, entity_type, ids):
+    """Get entities using their IDs.
+
+    Note that the query may be modified before passing it to this
+    function in order to save queries made to the database.
+
+    Args:
+        query (Query): SQLAlchemy Query object.
+        entity_type (str): Type of entity being queried.
+        ids (list): IDs of the target entities.
+
+    Returns:
+        Dictionary of objects of target entities keyed by their ID.
+    """
+    entity_model = ENTITY_MODELS[entity_type]
+    results = query.filter(entity_model.id in ids).all()
+    remaining_ids = list(set(ids) - {entity.id for entity in results})
+    entities = {entity.id: entity for entity in results}
+
+    if remaining_ids:
+        raise mb_exceptions.NoDataFoundException(
+            "Couldn't find entities with IDs: {ids}".format(ids=remaining_ids))
+
     return entities

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ msgpack-python==0.4.8
 requests==2.18.1
 SQLAlchemy==1.2.5
 mbdata==2017.6.2
+sqlalchemy-dst

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,4 @@ msgpack-python==0.4.8
 requests==2.18.1
 SQLAlchemy==1.2.5
 mbdata==2017.6.2
-sqlalchemy-dst
+sqlalchemy-dst==1.0.1


### PR DESCRIPTION
This is part of [BU-17](https://tickets.metabrainz.org/browse/BU-17).

After looking at a couple libraries for serializing SQLAlchemy rows to dicts, [sqlalchemy-dst](https://github.com/yarbshk/sqlalchemy-dst) seems like a well documented and still maintained library.

In this PR I've added the editor entity and the respective tests to demonstrate automatic serialization.