### PR TITLE
Update python3 version to 3.8

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,13 +1,13 @@
 Flask==1.0.2
 Jinja2==2.10.1
-werkzeug==0.15.5
+werkzeug==0.16.0
 Flask-DebugToolbar==0.10.1
 Flask-UUID==0.2
 raven[flask]==6.6.0
 certifi
 redis==2.10.5
 msgpack-python==0.4.8
-requests==2.20.0
+requests==2.22.0
 SQLAlchemy==1.3.3
 mbdata==25.0.0
 sqlalchemy-dst==1.0.1

--- a/test/Dockerfile.py3
+++ b/test/Dockerfile.py3
@@ -1,4 +1,4 @@
-FROM metabrainz/python:3.6
+FROM metabrainz/python:3.8
 
 ENV DOCKERIZE_VERSION v0.2.0
 RUN wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \


### PR DESCRIPTION
Update `python3` version to `python3.8`. Updated the version for `werkzeug` and `requests` modules too as some modules were marked deprecated in 0.16.0 and we should start fixing them too. 