### PR TITLE
use setuptools_scm to get version number

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,12 @@ For this project we are using [semantic versioning](http://semver.org/). If
 you want to make a new release:
 
 1. Create a new tag in git using the following format: `v<MAJOR>.<MINOR>.<PATCH>`.
+
+       git tag v1.x.0
+       git push --tags
+
 2. Create a release on GitHub based on that tag. Specify changes that were made.
+  https://github.com/metabrainz/brainzutils-python/releases/new
 
 When updating underlying dependencies keep in mind breaking changes that they
 might have. Update version of `brainzutils-python` accordingly.

--- a/brainzutils/__init__.py
+++ b/brainzutils/__init__.py
@@ -1,1 +1,7 @@
-__version__ = '1.14.1'
+from pkg_resources import get_distribution, DistributionNotFound
+
+try:
+    __version__ = get_distribution(__name__).version
+except DistributionNotFound:
+     # package is not installed
+    pass

--- a/setup.py
+++ b/setup.py
@@ -1,15 +1,15 @@
 #!/usr/bin/env python
 
 from setuptools import setup, find_packages
-from brainzutils import __version__
 
 setup(
     name="brainzutils",
-    version=__version__,
     description="Python tools for MetaBrainz projects",
     author="MetaBrainz Foundation",
     author_email="support@metabrainz.org",
     py_modules=["brainzutils"],
     packages=find_packages(),
+    use_scm_version=True,
+    setup_requires=['setuptools_scm'],
     install_requires=open("requirements.txt").read().split(),
 )


### PR DESCRIPTION
On a recommendation from @freso, this uses the [`setuptools_scm`](https://github.com/pypa/setuptools_scm/) package to get version numbers from the current git tag, and means that we no longer have to update `__init__.py`.

I tested it by making a virtualenv, making a new tag, `v1.15.0`, and running setup.py install. Then I went to a different directory (so that python didn't pick up the source folder as the module) and ran this:

```
>>> import brainzutils
>>> brainzutils.__version__
'1.15.0'
>>>
```

It seems to work well. Even with the v in the tag, it doesn't show this in the version, which is good.

There are a few caveats. First, we're using the setup.py usage: https://github.com/pypa/setuptools_scm/#setuppy-usage
We can't use pyproject.toml because the version of setuptools used in our python 2.7 image is only v40. We can look at improving this in the future.
Also, I use setuptools to get the version number: https://github.com/pypa/setuptools_scm/#retrieving-package-version-at-runtime
instead of importlib, because of python 2.7.  

https://tickets.metabrainz.org/browse/BU-33