### PR TITLE
BU-34: Simple metrics system

### DIFF
--- a/brainzutils/cache.py
+++ b/brainzutils/cache.py
@@ -243,6 +243,28 @@ def increment(key, namespace=None):
 
 
 @init_required
+def hincrby(name, key, amount, namespace=None):
+    return _r.hincrby(_prep_keys_list([name], namespace)[0], key, amount)
+
+
+@init_required
+def hgetall(name, namespace=None):
+    return _r.hgetall(_prep_keys_list([name], namespace)[0])
+
+
+@init_required
+def hkeys(name, namespace=None):
+    return _r.hkeys(_prep_keys_list([name], namespace)[0])
+
+
+@init_required
+def hdel(name, keys, namespace=None):
+    if not isinstance(keys, list):
+        keys = [keys]
+    return _r.hdel(_prep_keys_list([name], namespace)[0], keys)
+
+
+@init_required
 def flush_all():
     _r.flushdb()
 

--- a/brainzutils/cache.py
+++ b/brainzutils/cache.py
@@ -248,7 +248,7 @@ def hincrby(name, key, amount, namespace=None):
 
     Args:
         name: Name of the hash
-        key: Key of the item in the has to increment
+        key: Key of the item in the hash to increment
         amount: the number to increment the key by
         namespace: Namespace for the name
 
@@ -284,6 +284,24 @@ def hkeys(name, namespace=None):
         A list of [key] values for all keys in the hash
     """
     return _r.hkeys(_prep_keys_list([name], namespace)[0])
+
+
+@init_required
+def hset(name, key, value, namespace=None):
+    """Delete the specified keys from a hash using HDEL.
+    Note that the ``keys`` argument must be a list. This differs from the underlying redis
+    library's version of this command, which takes varargs.
+
+    Args:
+        name: Name of the hash
+        key: Key of the item in the hash to set
+        value: value to set the item to
+        namespace: Namespace for the name
+
+    Returns:
+        the number of keys deleted from the hash
+    """
+    return _r.hset(_prep_keys_list([name], namespace)[0], key, value)
 
 
 @init_required

--- a/brainzutils/cache.py
+++ b/brainzutils/cache.py
@@ -302,7 +302,7 @@ def hdel(name, keys, namespace=None):
     """
     if not isinstance(keys, list):
         keys = [keys]
-    return _r.hdel(_prep_keys_list([name], namespace)[0], keys)
+    return _r.hdel(_prep_keys_list([name], namespace)[0], *keys)
 
 
 @init_required

--- a/brainzutils/cache.py
+++ b/brainzutils/cache.py
@@ -244,21 +244,62 @@ def increment(key, namespace=None):
 
 @init_required
 def hincrby(name, key, amount, namespace=None):
+    """Increment a hashes key by a given amount using HINCRBY
+
+    Args:
+        name: Name of the hash
+        key: Key of the item in the has to increment
+        amount: the number to increment the key by
+        namespace: Namespace for the name
+
+    Returns:
+        An integer equal to the value after increment
+    """
     return _r.hincrby(_prep_keys_list([name], namespace)[0], key, amount)
 
 
 @init_required
 def hgetall(name, namespace=None):
+    """Get all keys and values for a hash using HGETALL
+
+    Args:
+        name: Name of the hash
+        namespace: Namespace for the name
+
+    Returns:
+        A dictionary of {key: value} items for all keys in the hash
+    """
     return _r.hgetall(_prep_keys_list([name], namespace)[0])
 
 
 @init_required
 def hkeys(name, namespace=None):
+    """Get all keys for a hash using HKEYS
+
+    Args:
+        name: Name of the hash
+        namespace: Namespace for the name
+
+    Returns:
+        A list of [key] values for all keys in the hash
+    """
     return _r.hkeys(_prep_keys_list([name], namespace)[0])
 
 
 @init_required
 def hdel(name, keys, namespace=None):
+    """Delete the specified keys from a hash using HDEL.
+    Note that the ``keys`` argument must be a list. This differs from the underlying redis
+    library's version of this command, which takes varargs.
+
+    Args:
+        name: Name of the hash
+        keys: a list of the keys to delete from the has
+        namespace: Namespace for the name
+
+    Returns:
+        the number of keys deleted from the hash
+    """
     if not isinstance(keys, list):
         keys = [keys]
     return _r.hdel(_prep_keys_list([name], namespace)[0], keys)

--- a/brainzutils/flask/__init__.py
+++ b/brainzutils/flask/__init__.py
@@ -12,14 +12,14 @@ class CustomFlask(Flask):
                  *args, **kwargs):
         """Create an instance of Flask app.
 
-        See original documentation for Flask.
+            See original documentation for Flask.
 
-        Args:
-            import_name (str): Name of the application package.
-            config_file (str): Path to a config file that needs to be loaded.
-                Should be in a form of Python module.
-            debug (bool): Override debug value.
-            use_flask_uuid (bool): Turn on Flask-UUID extension if set to True.
+            Arguments:
+                import_name (str): Name of the application package.
+                config_file (str): Path to a config file that needs to be loaded.
+                    Should be in a form of Python module.
+                debug (bool): Override debug value.
+                use_flask_uuid (bool): Turn on Flask-UUID extension if set to True.
         """
         super(CustomFlask, self).__init__(import_name, *args, **kwargs)
         if config_file:

--- a/brainzutils/metrics.py
+++ b/brainzutils/metrics.py
@@ -1,33 +1,108 @@
 from __future__ import division
 
+from functools import wraps
+
 import six
+from redis import ResponseError
 
 from brainzutils import cache
 
 NAMESPACE_METRICS = "metrics"
+REDIS_MAX_INTEGER = 2**63-1
+RESERVED_TAG_NAMES = {"tag", "date"}
+
+_metrics_project_name = None
+
+
+def init(project):
+    global _metrics_project_name
+    _metrics_project_name = project
+
+
+def metrics_init_required(f):
+    @wraps(f)
+    def decorated(*args, **kwargs):
+        if not _metrics_project_name:
+            raise RuntimeError("Metrics module needs to be initialized before use")
+        return f(*args, **kwargs)
+    return decorated
 
 
 @cache.init_required
+@metrics_init_required
 def increment(metric_name, amount=1):
-    """Increment the counter of the current bucket by a set amount.
+    """Increment the counter for a metric by a set amount. A metric is a counter that can increment over time
+    and can be used for monitoring any statistic.
+
+    If incrementing the counter causes it to go over redis' internal counter limit of 2**63-1, the counter
+    is reset to 0. The metric name ``tag`` is reserved and cannot be used.
 
     Arguments:
         metric_name: the name of a metric
-        amount: the amount to increase the counter by (default: 1)"""
+        amount: the amount to increase the counter by, must be 1 or greater (default: 1)
 
-    ret = cache.hincrby("counter", metric_name, amount, namespace=NAMESPACE_METRICS)
+    Raises:
+        ValueError if amount is less than 1 or greater than 2**63-1
+        ValueError if the reserved metric name ``tag`` is used
+    """
+
+    if amount < 1:
+        raise ValueError("amount must be 1 or greater")
+    if amount > REDIS_MAX_INTEGER:
+        raise ValueError("amount is too large")
+    if metric_name in RESERVED_TAG_NAMES:
+        raise ValueError("the name '{}' is reserved".format(metric_name))
+
+    try:
+        ret = cache.hincrby(_metrics_project_name, metric_name, amount, namespace=NAMESPACE_METRICS)
+    except ResponseError as e:
+        # If the current value is too large, redis will return this error message.
+        # Reset to 0 and re-increment
+        if e.args and "increment or decrement would overflow" in e.args[0]:
+            cache.hset(_metrics_project_name, metric_name, 0, namespace=NAMESPACE_METRICS)
+            ret = cache.hincrby(_metrics_project_name, metric_name, amount, namespace=NAMESPACE_METRICS)
+        else:
+            raise
 
     return ret
 
 
 @cache.init_required
-def stats(metric_names):
-    """Get all current counts for this metrics named by ``metric_names``."""
+@metrics_init_required
+def remove(metric_name):
+    """Remove a metric from the local counter. When a metric is removed it will no longer
+    appear in the data returned by :meth:`stats`
 
-    counters = cache.hgetall("counter", namespace=NAMESPACE_METRICS)
-    ret = {}
-    str_key_counters = {six.ensure_text(k): int(v) for k, v in counters.items()}
-    for metric in metric_names:
-        if metric in str_key_counters:
-            ret[metric] = str_key_counters[metric]
+    Arguments:
+        metric_name: The metric to remove
+    """
+
+    return cache.hdel(_metrics_project_name, [metric_name], namespace=NAMESPACE_METRICS)
+
+
+@cache.init_required
+@metrics_init_required
+def stats():
+    """Get the current value for metrics in the currently configured project.
+
+    This can be used in a flask view to return the current metrics::
+
+        @bp.route('/metric_statistics')
+        def increment_metric():
+            return jsonify(metrics.stats())
+
+    The view can be read by telegraf or any other logging system.
+
+    Returns:
+        A dictionary containing metric names and counts for the current project, as well
+        as a field ``tag`` containing the current project name. For example::
+
+        {"new_users": 100,
+         "computed_stats": 20,
+         "tag": "listenbrainz.org"}
+    """
+
+    counters = cache.hgetall(_metrics_project_name, namespace=NAMESPACE_METRICS)
+    ret = {six.ensure_text(k): int(v) for k, v in counters.items()}
+    ret["tag"] = _metrics_project_name
     return ret

--- a/brainzutils/metrics.py
+++ b/brainzutils/metrics.py
@@ -99,9 +99,9 @@ def stats():
         A dictionary containing metric names and counts for the current project, as well
         as a field ``tag`` containing the current project name. For example::
 
-        {"new_users": 100,
-         "computed_stats": 20,
-         "tag": "listenbrainz.org"}
+            {"new_users": 100,
+             "computed_stats": 20,
+             "tag": "listenbrainz.org"}
     """
 
     counters = cache.hgetall(_metrics_project_name, namespace=NAMESPACE_METRICS)
@@ -119,7 +119,7 @@ def set_count(metric_name, **data):
     For example, if you have an import process that happens periodically,
     you could call something like::
 
-    metrics.set_count('import', artists=10, releases=27, recordings=100)
+        metrics.set_count('import', artists=10, releases=27, recordings=100)
 
     to set some fixed counts for the ``import`` metric. These metrics are
     stored with the time that the method is called.
@@ -181,12 +181,12 @@ def stats_count(metric_name):
         the requested metric, and ``date`` containing the date that the metric was last written.
         For example::
 
-        {"artists": 10,
-         "releases": 29,
-         "recordings": 100,
-         "date": "2021-02-17T13:02:18",
-         "metric": "import",
-         "tag": "listenbrainz.org"}
+            {"artists": 10,
+             "releases": 29,
+             "recordings": 100,
+             "date": "2021-02-17T13:02:18",
+             "metric": "import",
+             "tag": "listenbrainz.org"}
     """
 
     metric_key = _metrics_project_name + ":" + metric_name

--- a/brainzutils/metrics.py
+++ b/brainzutils/metrics.py
@@ -1,105 +1,33 @@
 from __future__ import division
 
-import datetime
-
 import six
 
 from brainzutils import cache
 
 NAMESPACE_METRICS = "metrics"
 
-# Keep this many hours of old cache items in each key
-HOURS_TO_KEEP = 12
 
-METRICS_RANGE_MINUTE = 1
-METRICS_RANGE_10MIN = 10
-METRICS_RANGE_HOUR = 60
-
-
+@cache.init_required
 def increment(metric_name, amount=1):
-    """Increment a metric with the name ``metric_name`` with a default range of one hour
+    """Increment the counter of the current bucket by a set amount.
+
     Arguments:
         metric_name: the name of a metric
-        amount (int): the amount to increment the metrric by (default 1)
-    """
-    metric = Metrics(metric_name, METRICS_RANGE_HOUR)
-    metric.increment(amount)
+        amount: the amount to increase the counter by (default: 1)"""
+
+    ret = cache.hincrby("counter", metric_name, amount, namespace=NAMESPACE_METRICS)
+
+    return ret
 
 
-def stats(metric_name):
-    """Get an overview of the metrics for a given metric name"""
-    metric = Metrics(metric_name, METRICS_RANGE_HOUR)
-    return metric.stats()
+@cache.init_required
+def stats(metric_names):
+    """Get all current counts for this metrics named by ``metric_names``."""
 
-
-class Metrics:
-    """Metrics keeps basic counts of the number of events that occur over time.
-    This can be used to count events in a system, grouping events in a time range together
-    (e.g. all events that happened in 10 minutes, or in an hour).
-
-    Items are stored in a separate cache namespace.
-
-    Example usage:
-
-        counter = Metrics("user-signups", METRICS_RANGE_10MIN)
-        counter.increment()
-
-        ...
-        return jsonify(counter.stats())
-
-    Dates are stored in UTC.
-
-    TODO: Ranges must be multiples of 60 minutes. If not, the last bucket of the hour may be shorter than the
-      duration of `range`
-    """
-
-    @cache.init_required
-    def __init__(self, name, range):
-        """Create a metrics object. The BU cache must be initalised first.
-
-        Arguments:
-            name: the name of the metrics to record.
-            range: the duration in minutes of each bucket"""
-        self.name = name
-        self.range = range
-
-    def increment(self, amount=1):
-        """Increment the counter of the current bucket by a set amount.
-
-        Arguments:
-            amount: the amount to increase the counter by (default: 1)"""
-
-        now = datetime.datetime.now(tz=datetime.timezone.utc)
-        minute = now.minute // self.range * self.range
-        now = now.replace(minute=minute, second=0, microsecond=0)
-        field = now.isoformat()
-
-        ret = cache.hincrby(self.name, field, amount, namespace=NAMESPACE_METRICS)
-        tokeep = int(60 // self.range * HOURS_TO_KEEP)
-        self._expire_old_items(tokeep)
-        return ret
-
-    def _expire_old_items(self, tokeep):
-        """Remove old items from the redis hash
-        TODO: This kind of keeps HOURS_TO_KEEP items, but only if all buckets exist.
-          if there is a gap (bucket with 0 items) then it will keep more than
-          HOURS_TO_KEEP hours worth of items
-        """
-        items = cache.hkeys(self.name, namespace=NAMESPACE_METRICS)
-        toremove = sorted(items)[tokeep:]
-        if toremove:
-            cache.hdel(self.name, toremove, namespace=NAMESPACE_METRICS)
-
-    def stats(self):
-        """Get all current stats for this counter.
-         Returns a dictionary of {bucket: count} items where bucket
-         is the UTC timestamp that the bucket starts at, in iso8601 format"""
-        counters = cache.hgetall(self.name, namespace=NAMESPACE_METRICS)
-        ret = []
-        for key in sorted(counters.keys()):
-            ret.append({
-                'time': six.ensure_text(key),
-                self.name: int(counters[key])
-            })
-
-        return ret
+    counters = cache.hgetall("counter", namespace=NAMESPACE_METRICS)
+    ret = {}
+    str_key_counters = {six.ensure_text(k): int(v) for k, v in counters.items()}
+    for metric in metric_names:
+        if metric in str_key_counters:
+            ret[metric] = str_key_counters[metric]
+    return ret

--- a/brainzutils/metrics.py
+++ b/brainzutils/metrics.py
@@ -99,7 +99,7 @@ class Metrics:
         for key in sorted(counters.keys()):
             ret.append({
                 'time': six.ensure_text(key),
-                'amount': int(counters[key])
+                self.name: int(counters[key])
             })
 
         return ret

--- a/brainzutils/test/test_metrics.py
+++ b/brainzutils/test/test_metrics.py
@@ -1,5 +1,6 @@
 import unittest
 import mock
+from freezegun import freeze_time
 from redis import ResponseError
 
 from brainzutils import cache
@@ -70,6 +71,51 @@ class MetricsTestCase(unittest.TestCase):
         expected = {'valueone': 1,
                     'valuetwo': 20,
                     'somethingelse': 8,
+                    'tag': 'listenbrainz.org'}
+
+        self.assertEqual(stats, expected)
+
+    @freeze_time('2021-02-15T10:22:00')
+    @mock.patch('brainzutils.metrics.cache.hset')
+    @mock.patch('brainzutils.metrics.cache.delete')
+    def test_set_count(self, mock_del, hset):
+        metrics.init('listenbrainz.org')
+        metrics.set_count('dataimport', artists=10, recordings=2)
+
+        mock_del.assert_called_with('listenbrainz.org:dataimport', namespace='metrics')
+        hset.assert_has_calls([mock.call('listenbrainz.org:dataimport', 'artists', 10, namespace='metrics'),
+                               mock.call('listenbrainz.org:dataimport', 'recordings', 2, namespace='metrics'),
+                               mock.call('listenbrainz.org:dataimport', 'date', '2021-02-15T10:22:00', namespace='metrics')],
+                              any_order=True)
+
+    def test_set_count_invalid_values(self):
+        metrics.init('listenbrainz.org')
+        with self.assertRaises(ValueError):
+            metrics.set_count('dataimport', date=1)
+
+        with self.assertRaises(ValueError):
+            metrics.set_count('dataimport', artists='not-an-int')
+
+    @mock.patch('brainzutils.metrics.cache.delete')
+    def test_remove_count(self, mock_del):
+        metrics.init('listenbrainz.org')
+        metrics.remove_count('dataimport')
+        mock_del.assert_called_with('listenbrainz.org:dataimport', namespace='metrics')
+
+    @mock.patch('brainzutils.metrics.cache.hgetall')
+    def test_stats_count(self, hgetall):
+        metrics.init('listenbrainz.org')
+        hgetall.return_value = {b'valueone': b'1',
+                                b'valuetwo': b'20',
+                                b'date': b'2021-02-12T13:02:18'}
+
+        stats = metrics.stats_count('dataimport')
+        hgetall.assert_called_with('listenbrainz.org:dataimport', namespace='metrics')
+
+        expected = {'valueone': 1,
+                    'valuetwo': 20,
+                    'date': '2021-02-12T13:02:18',
+                    'metric': 'dataimport',
                     'tag': 'listenbrainz.org'}
 
         self.assertEqual(stats, expected)

--- a/brainzutils/test/test_metrics.py
+++ b/brainzutils/test/test_metrics.py
@@ -1,0 +1,62 @@
+import unittest
+import mock
+
+from freezegun import freeze_time
+
+from brainzutils import cache
+from brainzutils import metrics
+
+
+class MetricsTestCase(unittest.TestCase):
+
+    def setUp(self) -> None:
+        cache.init('redis')
+
+    @freeze_time('2020-10-14 14:20:21')
+    @mock.patch('brainzutils.metrics.cache.hincrby')
+    def test_increment_hourly(self, hincrby):
+        m = metrics.Metrics('test_m', metrics.METRICS_RANGE_HOUR)
+        m.increment(2)
+        hincrby.assert_called_with('test_m', '2020-10-14T14:00:00+00:00', 2, namespace='metrics')
+
+    @freeze_time('2020-10-14 14:25:21')
+    @mock.patch('brainzutils.metrics.cache.hincrby')
+    def test_increment_10_min(self, hincrby):
+        m = metrics.Metrics('test_m', metrics.METRICS_RANGE_10MIN)
+        m.increment()
+        hincrby.assert_called_with('test_m', '2020-10-14T14:20:00+00:00', 1, namespace='metrics')
+
+    @mock.patch('brainzutils.metrics.cache.hgetall')
+    def test_stats(self, hgetall):
+        hgetall.return_value = {b'2020-10-14T14:00:00+00:00': b'1',
+                                b'2020-10-14T15:00:00+00:00': b'20',
+                                b'2020-10-14T16:00:00+00:00': b'8'}
+
+        stats = metrics.stats('test_m')
+        hgetall.assert_called_with('test_m', namespace='metrics')
+
+        expected = [
+            {'time': '2020-10-14T14:00:00+00:00', 'amount': 1},
+            {'time': '2020-10-14T15:00:00+00:00', 'amount': 20},
+            {'time': '2020-10-14T16:00:00+00:00', 'amount': 8}
+        ]
+        self.assertEqual(stats, expected)
+
+    @mock.patch('brainzutils.metrics.cache.hkeys')
+    @mock.patch('brainzutils.metrics.cache.hdel')
+    def test_expire(self, hdel, hkeys):
+        hkeys.return_value = [b'2020-10-14T14:00:00+00:00',
+                              b'2020-10-14T18:00:00+00:00',
+                              b'2020-10-14T15:00:00+00:00',
+                              b'2020-10-14T16:00:00+00:00',
+                              b'2020-10-14T17:00:00+00:00']
+
+        m = metrics.Metrics('test_m', metrics.METRICS_RANGE_10MIN)
+        m._expire_old_items(2)
+        hkeys.assert_called_with('test_m', namespace='metrics')
+
+        hdel.assert_called_with('test_m',
+                                [b'2020-10-14T16:00:00+00:00',
+                                 b'2020-10-14T17:00:00+00:00',
+                                 b'2020-10-14T18:00:00+00:00'],
+                                namespace='metrics'),

--- a/brainzutils/test/test_metrics.py
+++ b/brainzutils/test/test_metrics.py
@@ -13,7 +13,7 @@ class MetricsTestCase(unittest.TestCase):
         cache.init('redis')
 
     def tearDown(self):
-        metrics._metrics_site_name = None
+        metrics._metrics_project_name = None
 
     @mock.patch('brainzutils.metrics.cache.hincrby')
     def test_increment(self, hincrby):

--- a/brainzutils/timeseries_stats.py
+++ b/brainzutils/timeseries_stats.py
@@ -1,0 +1,85 @@
+from __future__ import division
+
+import datetime
+
+import six
+
+from brainzutils import cache
+
+NAMESPACE_STATS = "timeseries_stats"
+
+# Keep this many hours of old cache items in each key
+HOURS_TO_KEEP = 12
+
+STATS_RANGE_MINUTE = 1
+STATS_RANGE_10MIN = 10
+STATS_RANGE_HOUR = 60
+
+
+class TimeseriesStats:
+    """TimeseriesStats keeps basic counts of the number of events that occur over time.
+    This can be used to count events in a system, grouping events in a time range together
+    (e.g. all events that happened in 10 minutes, or in an hour).
+
+    Items are stored in a separate cache namespace.
+
+    Example usage:
+
+        counter = TimeseriesStats("user-signups", STATS_RANGE_10MIN)
+        counter.increment()
+
+        ...
+        return jsonify(counter.stats())
+
+    Dates are stored in UTC.
+
+    TODO: Ranges must be multiples of 60 minutes. If not, the last bucket of the hour may be shorter than the
+      duration of `range`
+    """
+
+    @cache.init_required
+    def __init__(self, name, range):
+        """Create a stats object. The BU cache must be initalised first.
+
+        Arguments:
+            name: the name of the stats to record.
+            range: the duration in minutes of each bucket"""
+        self.name = name
+        self.range = range
+
+    def increment(self, amount=1):
+        """Increment the counter of the current bucket by a set amount.
+
+        Arguments:
+            amount: the amount to increase the counter by (default: 1)"""
+
+        now = datetime.datetime.utcnow()
+        minute = now.minute // self.range * self.range
+        now = now.replace(minute=minute, second=0, microsecond=0)
+        field = now.isoformat()
+
+        ret = cache.hincrby(self.name, field, amount, namespace=NAMESPACE_STATS)
+        tokeep = int(60 // self.range * HOURS_TO_KEEP)
+        self._expire_old_items(tokeep)
+        return ret
+
+    def _expire_old_items(self, tokeep):
+        """Remove old items from the redis hash
+        TODO: This kind of keeps HOURS_TO_KEEP items, but only if all buckets exist.
+          if there is a gap (bucket with 0 items) then it will keep more than
+          HOURS_TO_KEEP hours worth of items
+        """
+        items = cache.hkeys(self.name, namespace=NAMESPACE_STATS)
+        toremove = items[tokeep:]
+        if toremove:
+            cache.hdel(self.name, toremove)
+
+    def stats(self):
+        """Get all current stats for this counter.
+         Returns a dictionary of {bucket: count} items where bucket
+         is the UTC timestamp that the bucket starts at, in iso8601 format"""
+        counters = cache.hgetall(self.name, namespace=NAMESPACE_STATS)
+        ret = {}
+        for key in sorted(counters.keys()):
+            ret[six.ensure_text(key)] = int(counters[key])
+        return ret

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -9,6 +9,7 @@ BrainzUtils is a set of python tools used in projects by the MetaBrainz foundati
 
    cache
    flask
+   metrics
    mail
    musicbrainz_db/index
    ratelimit

--- a/docs/metrics.rst
+++ b/docs/metrics.rst
@@ -1,0 +1,7 @@
+Metrics
+=======
+
+The metrics module provides a way of storing numerical values that can can be stored in a statistics database.
+
+.. automodule:: brainzutils.metrics
+   :members:

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,4 +1,5 @@
 psycopg2-binary==2.8.6
+freezegun==1.0.0
 pytest==4.6.9
 pytest-cov==2.8.1
 pylint==1.9.4

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,5 +1,5 @@
 psycopg2-binary==2.8.6
-freezegun==1.0.0
+freezegun==0.3.15
 pytest==4.6.9
 pytest-cov==2.8.1
 pylint==1.9.4


### PR DESCRIPTION
This replaces https://github.com/metabrainz/brainzutils-python/pull/41, which was far too complex for what we needed.

Now we have the following:
* Init a metric by using `metrics.init()` once at app startup. This contains an identifier of the site name (e.g. acousticbrainz.org or beta.listenbrainz.org)
* when you need to increment a count, use `metrics.increment('metricname')`, and that's it
* Make an endpoint that returns `metrics.stats()` as json, and configure telegraf to read it.

Metrics are just stored by a continually increasing integer (max limit 2**63-1). Influx takes care of counting the difference between subsequent accesses of the stats endpoint to measure counts. If the counts reset back to 0 (for example if redis restarts), influx will just skip this one and continue counting from the next time that it polls