### PR TITLE
Test musicbrainz db methods against a real musicbrainz sample database

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
-sudo: required
+os: linux
+dist: focal
 
 language: python
 
@@ -7,22 +8,14 @@ services:
 
 
 install:
-  - docker-compose -f test/docker-compose.py2.yml -p brainzutils_py2_test build
-  - docker-compose -f test/docker-compose.py3.yml -p brainzutils_py3_test build
+  - docker-compose -f test/docker-compose.db.yml -p brainzutils_py3_test build
 
 script:
-  - docker-compose -f test/docker-compose.py2.yml -p brainzutils_py2_test up -d redis
-  - docker-compose -f test/docker-compose.py2.yml -p brainzutils_py2_test run --rm test
+  - docker-compose -f test/docker-compose.db.yml -p brainzutils_py3_test up -d redis
+  - travis_wait docker-compose -f test/docker-compose.db.yml -p brainzutils_py3_test run --rm test
       dockerize
       -wait tcp://redis:6379 -timeout 10s
-      py.test
-  - docker-compose -f test/docker-compose.py2.yml -p brainzutils_py2_test down
-
-  - sleep 2
-
-  - docker-compose -f test/docker-compose.py3.yml -p brainzutils_py3_test up -d redis
-  - docker-compose -f test/docker-compose.py3.yml -p brainzutils_py3_test run --rm test
       dockerize
-      -wait tcp://redis:6379 -timeout 10s
+      -wait tcp://musicbrainz_db:5432 -timeout 600s
       py.test
-  - docker-compose -f test/docker-compose.py3.yml -p brainzutils_py3_test down
+  - docker-compose -f test/docker-compose.db.yml -p brainzutils_py3_test down

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,19 @@ services:
 
 
 install:
+  - docker-compose -f test/docker-compose.py2.yml -p brainzutils_py2_test build
   - docker-compose -f test/docker-compose.db.yml -p brainzutils_py3_test build
 
 script:
+  - docker-compose -f test/docker-compose.py2.yml -p brainzutils_py2_test up -d redis
+  - docker-compose -f test/docker-compose.py2.yml -p brainzutils_py2_test run --rm test
+    dockerize
+    -wait tcp://redis:6379 -timeout 10s
+    py.test -m "not database"
+  - docker-compose -f test/docker-compose.py2.yml -p brainzutils_py2_test down
+
+  - sleep 2
+
   - docker-compose -f test/docker-compose.db.yml -p brainzutils_py3_test up -d redis
   - travis_wait docker-compose -f test/docker-compose.db.yml -p brainzutils_py3_test run --rm test
       dockerize

--- a/brainzutils/musicbrainz_db/tests/test_artist.py
+++ b/brainzutils/musicbrainz_db/tests/test_artist.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 import pytest
 
 from brainzutils.musicbrainz_db.unknown_entities import unknown_artist

--- a/brainzutils/musicbrainz_db/tests/test_artist.py
+++ b/brainzutils/musicbrainz_db/tests/test_artist.py
@@ -1,26 +1,21 @@
-from unittest import TestCase
-from mock import MagicMock
+import pytest
+
 from brainzutils.musicbrainz_db.test_data import artist_linkin_park, artist_jay_z
 from brainzutils.musicbrainz_db.unknown_entities import unknown_artist
 from brainzutils.musicbrainz_db import artist as mb_artist
 
 
-class ArtistTestCase(TestCase):
+@pytest.mark.database
+class TestArtist:
 
-    def setUp(self):
-        mb_artist.mb_session = MagicMock()
-        self.mock_db = mb_artist.mb_session.return_value.__enter__.return_value
-        self.artist_query = self.mock_db.query.return_value.options.return_value.filter.return_value.all
-
-    def test_get_by_id(self):
-        self.artist_query.return_value = [artist_linkin_park]
+    def test_get_by_id(self, engine):
         artist = mb_artist.get_artist_by_id("f59c5520-5f46-4d2c-b2c4-822eabf53419")
-        self.assertDictEqual(artist, {
+        assert artist == {
             "id": "f59c5520-5f46-4d2c-b2c4-822eabf53419",
             "name": "Linkin Park",
             "sort_name": "Linkin Park",
             "type": "Group"
-        })
+        }
 
     def test_fetch_multiple_artists(self):
         self.artist_query.return_value = [artist_jay_z, artist_linkin_park]

--- a/brainzutils/musicbrainz_db/tests/test_artist.py
+++ b/brainzutils/musicbrainz_db/tests/test_artist.py
@@ -1,6 +1,5 @@
 import pytest
 
-from brainzutils.musicbrainz_db.test_data import artist_linkin_park, artist_jay_z
 from brainzutils.musicbrainz_db.unknown_entities import unknown_artist
 from brainzutils.musicbrainz_db import artist as mb_artist
 
@@ -17,32 +16,26 @@ class TestArtist:
             "type": "Group"
         }
 
-    def test_fetch_multiple_artists(self):
-        self.artist_query.return_value = [artist_jay_z, artist_linkin_park]
+    def test_fetch_multiple_artists(self, engine):
         artists = mb_artist.fetch_multiple_artists([
             "f59c5520-5f46-4d2c-b2c4-822eabf53419",
             "f82bcf78-5b69-4622-a5ef-73800768d9ac",
         ])
-        self.assertDictEqual(artists["f82bcf78-5b69-4622-a5ef-73800768d9ac"], {
+        assert artists["f82bcf78-5b69-4622-a5ef-73800768d9ac"] == {
             "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
-            "name": "JAY Z",
-            "sort_name": "JAY Z",
+            "name": "JAY‐Z",
+            "sort_name": "JAY‐Z",
             "type": "Person",
-        })
-        self.assertDictEqual(artists["f59c5520-5f46-4d2c-b2c4-822eabf53419"], {
+        }
+        assert artists["f59c5520-5f46-4d2c-b2c4-822eabf53419"] == {
             "id": "f59c5520-5f46-4d2c-b2c4-822eabf53419",
             "name": "Linkin Park",
             "sort_name": "Linkin Park",
             "type": "Group",
-        })
+        }
 
-    def test_fetch_multiple_artists_empty(self):
-        self.artist_query.return_value = []
-        artists = mb_artist.fetch_multiple_artists([
-            "f59c5520-5f46-4d2c-b2c4-822eabf53419",
-            "f82bcf78-5b69-4622-a5ef-73800768d9ac",
-        ],
-        includes=['artist-rels', 'url-rels'],
-        unknown_entities_for_missing=True)
-        self.assertEqual(artists["f82bcf78-5b69-4622-a5ef-73800768d9ac"]["name"], unknown_artist.name)
-        self.assertEqual(artists["f59c5520-5f46-4d2c-b2c4-822eabf53419"]["name"], unknown_artist.name)
+    def test_fetch_multiple_artists_empty(self, engine):
+        artists = mb_artist.fetch_multiple_artists(["f59c5520-aaaa-aaaa-b2c4-822eabf53419"],
+                                                   includes=['artist-rels', 'url-rels'],
+                                                   unknown_entities_for_missing=True)
+        assert artists["f59c5520-aaaa-aaaa-b2c4-822eabf53419"]["name"] == unknown_artist.name

--- a/brainzutils/musicbrainz_db/tests/test_editor.py
+++ b/brainzutils/musicbrainz_db/tests/test_editor.py
@@ -1,66 +1,105 @@
-from unittest import TestCase
-from mock import MagicMock
-from brainzutils.musicbrainz_db.test_data import editor_dt, editor_date, editor_1, editor_2
-from brainzutils.musicbrainz_db.unknown_entities import unknown_editor
+from datetime import datetime
+
+import pytest
+from mbdata.models import Editor
+from psycopg2.tz import FixedOffsetTimezone
+
 from brainzutils.musicbrainz_db import editor as mb_editor
+from brainzutils.musicbrainz_db.unknown_entities import unknown_editor
 
 
-class EditorTestCase(TestCase):
-    def setUp(self):
-        mb_editor.mb_session = MagicMock()
-        self.mock_db = mb_editor.mb_session.return_value.__enter__.return_value
-        self.editor_query = self.mock_db.query.return_value.filter.return_value.all
+@pytest.mark.database
+class TestEditor:
+    editor_dt = datetime(2014, 12, 1, 14, 6, 42, 321443, tzinfo=FixedOffsetTimezone(offset=0, name=None))
 
-        self.editor_1_dict = {
-            "id": 2323,
-            "name": "Editor 1",
-            "privs": 0,
-            "email": None,
-            "website": None,
-            "bio": None,
-            "member_since": editor_dt,
-            "email_confirm_date": editor_dt,
-            "last_login_date": editor_dt,
-            "last_updated": editor_dt,
-            "birth_date": None,
-            "deleted": False,
-            "gender": None,
-            "area": None,
-        }
+    editor_1 = dict(id=2323, name="Editor 1", privs=0, member_since=editor_dt, email_confirm_date=editor_dt,
+                    last_login_date=editor_dt, last_updated=editor_dt, deleted=False, password="{CLEARTEXT}pass",
+                    ha1="3f3edade87115ce351d63f42d92a1834")
+    expected_editor_1 = {
+        'area': None,
+        'bio': None,
+        'birth_date': None,
+        'deleted': False,
+        'email': None,
+        'email_confirm_date': editor_dt,
+        'gender': None,
+        'id': 2323,
+        'last_login_date': editor_dt,
+        'last_updated': editor_dt,
+        'member_since': editor_dt,
+        'name': 'Editor 1',
+        'privs': 0,
+        'website': None
+    }
 
-        self.editor_2_dict = {
-            "id": 2324,
-            "name": "Editor 2",
-            "privs": 3,
-            "email": "editor@example.com",
-            "website": "example.com",
-            "bio": "Random\neditor",
-            "member_since": editor_dt,
-            "email_confirm_date": editor_dt,
-            "last_login_date": editor_dt,
-            "last_updated": editor_dt,
-            "birth_date": editor_date,
-            "deleted": False,
-            "gender": None,
-            "area": None,
-        }
+    editor_2 = dict(id=2324, name="Editor 2", privs=3, email="editor@example.com", website="example.com",
+                    bio="Random\neditor", member_since=editor_dt, email_confirm_date=editor_dt,
+                    last_login_date=editor_dt, last_updated=editor_dt, deleted=False, area=None,
+                    password="$2b$12$2odiKUAGktuwM2J.tp/uZ.54bniapSMjCln3J1TfC6zx74QFuawQ6",
+                    ha1="3f3edade87115ce351d63f42d92a1834")
+    expected_editor_2 = {
+        "id": 2324,
+        "name": "Editor 2",
+        "privs": 3,
+        "email": "editor@example.com",
+        "website": "example.com",
+        "bio": "Random\neditor",
+        "member_since": editor_dt,
+        "email_confirm_date": editor_dt,
+        "last_login_date": editor_dt,
+        "last_updated": editor_dt,
+        "birth_date": None,
+        "deleted": False,
+        "gender": None,
+        "area": None,
+    }
 
-    def test_get_by_id(self):
-        self.editor_query.return_value = [editor_1]
-        editor = mb_editor.get_editor_by_id(2323)
-        self.assertDictEqual(editor, self.editor_1_dict)
+    def test_get_by_id(self, session):
+        # Manually adding and deleting data in tests can get tedious. However, we have only two tests for which this is
+        # needed. In case in future we need to add more tests where the test database needs to be modified, we should
+        # explore other alternatives to ease the process.
+        with session as db:
+            # The editors table in test database has many empty columns and fields like last_login_date may change with
+            # new dump.
+            insert_editor_1 = Editor(**TestEditor.editor_1)
+            db.add(insert_editor_1)
+            db.commit()
+            try:
+                editor = mb_editor.get_editor_by_id(2323)
+                assert editor == TestEditor.expected_editor_1
+            finally:
+                # regardless whether the assertion fails or passes, delete the inserted editor to prevent side effects
+                # on subsequent tests
+                db.delete(insert_editor_1)
+                db.commit()
 
-    def test_fetch_multiple_editors(self):
-        self.editor_query.return_value = [editor_1, editor_2]
-        editors = mb_editor.fetch_multiple_editors([2323, 2324])
-        self.assertDictEqual(editors[2323], self.editor_1_dict)
-        self.assertDictEqual(editors[2324], self.editor_2_dict)
-    
-    def test_fetch_multiple_editors_empty(self):
-        self.editor_query.return_value = []
+    def test_fetch_multiple_editors(self, session):
+        # Manually adding and deleting data in tests can get tedious. However, we have only two tests for which this is
+        # needed. In case in future we need to add more tests where the test database needs to be modified, we should
+        # explore other alternatives to ease the process.
+        with session as db:
+            # The editors table in test database has many empty columns and fields like last_login_date may change with
+            # new dump.
+            insert_editor_1 = Editor(**TestEditor.editor_1)
+            insert_editor_2 = Editor(**TestEditor.editor_2)
+            db.add(insert_editor_1)
+            db.add(insert_editor_2)
+            db.commit()
+            try:
+                editors = mb_editor.fetch_multiple_editors([2323, 2324])
+                assert editors[2323] == TestEditor.expected_editor_1
+                assert editors[2324] == TestEditor.expected_editor_2
+            finally:
+                # regardless whether the assertion fails or passes, delete the inserted editor to prevent side effects
+                # on subsequent tests
+                db.delete(insert_editor_1)
+                db.delete(insert_editor_2)
+                db.commit()
+
+    def test_fetch_multiple_editors_empty(self, engine):
         editors = mb_editor.fetch_multiple_editors(
             [2323, 2324],
             unknown_entities_for_missing=True,
         )
-        self.assertEqual(editors[2323]["name"], unknown_editor.name)
-        self.assertEqual(editors[2324]["name"], unknown_editor.name)
+        assert editors[2323]["name"] == unknown_editor.name
+        assert editors[2324]["name"] == unknown_editor.name

--- a/brainzutils/musicbrainz_db/tests/test_label.py
+++ b/brainzutils/musicbrainz_db/tests/test_label.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 import pytest
 
 from brainzutils.musicbrainz_db.unknown_entities import unknown_label

--- a/brainzutils/musicbrainz_db/tests/test_label.py
+++ b/brainzutils/musicbrainz_db/tests/test_label.py
@@ -1,53 +1,42 @@
-from unittest import TestCase
-from mock import MagicMock
-from brainzutils.musicbrainz_db.test_data import label_dreamville, label_roc_a_fella
+import pytest
+
 from brainzutils.musicbrainz_db.unknown_entities import unknown_label
 from brainzutils.musicbrainz_db import label as mb_label
 
 
-class LabelTestCase(TestCase):
+@pytest.mark.database
+class TestLabel:
 
-    def setUp(self):
-        mb_label.mb_session = MagicMock()
-        self.mock_db = mb_label.mb_session.return_value.__enter__.return_value
-        self.label_query = self.mock_db.query.return_value.options.return_value.options.return_value.filter.return_value.all
-
-    def test_get_label_by_id(self):
-        self.label_query.return_value = [label_dreamville]
-        label = mb_label.get_label_by_id('1aed8c3b-8e1e-46f8-b558-06357ff5f298')
-        self.assertDictEqual(label, {
-            "id": "1aed8c3b-8e1e-46f8-b558-06357ff5f298",
-            "name": "Dreamville",
-            "type": "Imprint",
-            "area": "United States",
-        })
-
-    def test_fetch_multiple_labels(self):
-        self.label_query.return_value = [label_dreamville, label_roc_a_fella]
-        labels = mb_label.fetch_multiple_labels([
-            '1aed8c3b-8e1e-46f8-b558-06357ff5f298',
-            '4cccc72a-0bd0-433a-905e-dad87871397d'
-        ])
-        self.assertDictEqual(labels["1aed8c3b-8e1e-46f8-b558-06357ff5f298"], {
-            "id": "1aed8c3b-8e1e-46f8-b558-06357ff5f298",
-            "name": "Dreamville",
-            "type": "Imprint",
-            "area": "United States",
-        })
-        self.assertDictEqual(labels["4cccc72a-0bd0-433a-905e-dad87871397d"], {
+    def test_get_label_by_id(self, engine):
+        label = mb_label.get_label_by_id('4cccc72a-0bd0-433a-905e-dad87871397d')
+        assert label == {
             "id": "4cccc72a-0bd0-433a-905e-dad87871397d",
-            "name": "Roc-A-Fella Records",
+            "name": "Roc‐A‐Fella Records",
             "type": "Original Production",
             "area": "United States",
-        })
+        }
 
-    def test_fetch_multiple_labels_empty(self):
-        self.label_query.return_value = []
+    def test_fetch_multiple_labels(self, engine):
         labels = mb_label.fetch_multiple_labels([
-            '1aed8c3b-8e1e-46f8-b558-06357ff5f298',
+            'c595c289-47ce-4fba-b999-b87503e8cb71',
             '4cccc72a-0bd0-433a-905e-dad87871397d'
-        ],
-        includes=['artist-rels', 'url-rels'],
-        unknown_entities_for_missing=True)
-        self.assertEqual(labels["1aed8c3b-8e1e-46f8-b558-06357ff5f298"]["name"], unknown_label.name)
-        self.assertEqual(labels["4cccc72a-0bd0-433a-905e-dad87871397d"]["name"], unknown_label.name)
+        ])
+        assert labels["c595c289-47ce-4fba-b999-b87503e8cb71"] == {
+            "id": "c595c289-47ce-4fba-b999-b87503e8cb71",
+            "name": "Warner Bros. Records",
+            "comment": '1958–2019; “WB” logo, with or without “records” beneath or on banner across',
+            "type": "Imprint",
+            "area": "United States",
+        }
+        assert labels["4cccc72a-0bd0-433a-905e-dad87871397d"] == {
+            "id": "4cccc72a-0bd0-433a-905e-dad87871397d",
+            "name": "Roc‐A‐Fella Records",
+            "type": "Original Production",
+            "area": "United States",
+        }
+
+    def test_fetch_multiple_labels_empty(self, engine):
+        labels = mb_label.fetch_multiple_labels(['1aed8c3b-8e1e-46f8-b558-06357ff5f298'],
+                                                includes=['artist-rels', 'url-rels'],
+                                                unknown_entities_for_missing=True)
+        assert labels["1aed8c3b-8e1e-46f8-b558-06357ff5f298"]["name"] == unknown_label.name

--- a/brainzutils/musicbrainz_db/tests/test_place.py
+++ b/brainzutils/musicbrainz_db/tests/test_place.py
@@ -1,44 +1,37 @@
-# -*- coding: utf-8 -*-
-from unittest import TestCase
-from mock import MagicMock
+import pytest
+
 from brainzutils.musicbrainz_db import place as mb_place
 from brainzutils.musicbrainz_db.unknown_entities import unknown_place
-from brainzutils.musicbrainz_db.test_data import place_suisto, place_verkatehdas
 
 
-class PlaceTestCase(TestCase):
+@pytest.mark.database
+class TestPlace:
 
-    def setUp(self):
-        mb_place.mb_session = MagicMock()
-        self.mock_db = mb_place.mb_session.return_value.__enter__.return_value
-        self.place_query = self.mock_db.query.return_value.options.return_value.options.return_value.filter.return_value.all
+    def test_get_by_id(self, engine):
+        place = mb_place.get_place_by_id('4352063b-a833-421b-a420-e7fb295dece0')
+        assert place['name'] == 'Royal Albert Hall'
+        assert place['type'] == 'Venue'
+        assert place['coordinates'] == {
+            'latitude': 51.50105,
+            'longitude': -0.17748
+        }
+        assert place['area'] == {
+            'id': 'b9576171-3434-4d1b-8883-165ed6e65d2f',
+            'name': 'Kensington and Chelsea',
+        }
 
-    def test_get_by_id(self):
-        self.place_query.return_value = [place_suisto]
-        place = mb_place.get_place_by_id('d71ffe38-5eaf-426b-9a2e-e1f21bc84609')
-        self.assertEqual(place['name'], 'Suisto')
-        self.assertEqual(place['type'], 'Venue')
-        self.assertDictEqual(place['coordinates'], {
-            'latitude': 60.997758,
-            'longitude': 24.477142
-        })
-        self.assertDictEqual(place['area'], {
-            'id': '4479c385-74d8-4a2b-bdab-f48d1e6969ba',
-            'name': 'Hämeenlinna',
-        })
+    def test_fetch_multiple_places(self, engine):
+        places = mb_place.fetch_multiple_places(
+            ['4352063b-a833-421b-a420-e7fb295dece0', '2056ad56-cea9-4536-9f2d-58765a38829c']
+        )
+        assert places['4352063b-a833-421b-a420-e7fb295dece0']['name'] == 'Royal Albert Hall'
+        assert places['2056ad56-cea9-4536-9f2d-58765a38829c']['name'] == 'Finnvox Studios'
 
-    def test_fetch_multiple_places(self):
-        self.place_query.return_value = [place_suisto, place_verkatehdas]
-        places = mb_place.fetch_multiple_places(['f9587914-8505-4bd1-833b-16a3100a4948', 'd71ffe38-5eaf-426b-9a2e-e1f21bc84609'])
-        self.assertEqual(places['d71ffe38-5eaf-426b-9a2e-e1f21bc84609']['name'], 'Suisto')
-        self.assertEqual(places['f9587914-8505-4bd1-833b-16a3100a4948']['name'], 'Verkatehdas')
-
-    def test_fetch_multiple_places_empty(self):
-        self.place_query.return_value = []
+    def test_fetch_multiple_places_empty(self, engine):
         places = mb_place.fetch_multiple_places(
             ['f9587914-8505-4bd1-833b-16a3100a4948', 'd71ffe38-5eaf-426b-9a2e-e1f21bc84609'],
             includes=['artist-rels', 'place-rels', 'url-rels'],
             unknown_entities_for_missing=True
         )
-        self.assertEqual(places['d71ffe38-5eaf-426b-9a2e-e1f21bc84609']['name'], unknown_place.name)
-        self.assertEqual(places['f9587914-8505-4bd1-833b-16a3100a4948']['name'], unknown_place.name)
+        assert places['d71ffe38-5eaf-426b-9a2e-e1f21bc84609']['name'] == unknown_place.name
+        assert places['f9587914-8505-4bd1-833b-16a3100a4948']['name'] == unknown_place.name

--- a/brainzutils/musicbrainz_db/tests/test_recording.py
+++ b/brainzutils/musicbrainz_db/tests/test_recording.py
@@ -1,109 +1,90 @@
+import pytest
+
 from brainzutils.musicbrainz_db import recording as mb_recording
-from brainzutils.musicbrainz_db.serialize import serialize_recording 
 from brainzutils.musicbrainz_db.unknown_entities import unknown_recording
-from brainzutils.musicbrainz_db.test_data import recording_numb_encore_explicit, recording_numb_encore_instrumental
-from unittest import TestCase
-from mock import MagicMock
 
 
-class RecordingTestCase(TestCase):
+@pytest.mark.database
+class TestRecording:
 
-    def setUp(self):
-        mb_recording.mb_session = MagicMock()
-        self.mock_db = mb_recording.mb_session.return_value.__enter__.return_value
-        self.recording_query = self.mock_db.query.return_value.options.return_value.\
-            options.return_value.options.return_value.filter.return_value.all
-
-    def test_get_recording_by_mbid(self):
+    def test_get_recording_by_mbid(self, engine):
         """ Tests if appropriate recording is returned for a given MBID. """
-
-        self.recording_query.return_value = [recording_numb_encore_explicit]
         recording = mb_recording.get_recording_by_mbid('daccb724-8023-432a-854c-e0accb6c8678', includes=['artists'])
 
-        self.assertDictEqual(recording,
-            {
+        assert recording == {
+            'id': 'daccb724-8023-432a-854c-e0accb6c8678',
+            'name': 'Numb / Encore',
+            'comment': 'explicit',
+            'length': 205.28,
+            'artist-credit-phrase': 'Jay-Z / Linkin Park',
+            'artists': [
+                {
+                    'id': 'f82bcf78-5b69-4622-a5ef-73800768d9ac',
+                    'name': 'JAY‐Z',
+                    'credited_name': 'Jay-Z',
+                    'join_phrase': ' / '
+                },
+                {
+                    'id': 'f59c5520-5f46-4d2c-b2c4-822eabf53419',
+                    'name': 'Linkin Park'
+                }
+            ]
+        }
+
+    def test_fetch_multiple_recordings(self, engine):
+        """ Tests if appropriate recordings are returned for a given list of MBIDs. """
+
+        mbids = ['daccb724-8023-432a-854c-e0accb6c8678', 'ae83579c-5f33-4a35-83f3-89206c44a426']
+        recordings = mb_recording.fetch_multiple_recordings(mbids, includes=['artists'])
+
+        assert recordings == {
+            'daccb724-8023-432a-854c-e0accb6c8678': {
                 'id': 'daccb724-8023-432a-854c-e0accb6c8678',
-                'name': 'Numb/Encore (explicit)',
+                'name': 'Numb / Encore',
+                'comment': 'explicit',
                 'length': 205.28,
-                'artist-credit-phrase': 'Jay-Z/Linkin Park',
-                'artists':[
+                'artist-credit-phrase': 'Jay-Z / Linkin Park',
+                'artists': [
                     {
                         'id': 'f82bcf78-5b69-4622-a5ef-73800768d9ac',
-                        'name': 'JAY Z',
+                        'name': 'JAY‐Z',
                         'credited_name': 'Jay-Z',
-                        'join_phrase': '/'
+                        'join_phrase': ' / '
                     },
                     {
                         'id': 'f59c5520-5f46-4d2c-b2c4-822eabf53419',
                         'name': 'Linkin Park'
                     }
                 ]
-            }
-        )
-    
-    def test_fetch_multiple_recordings(self):
-        """ Tests if appropriate recordings are returned for a given list of MBIDs. """
-
-        self.recording_query.return_value = [recording_numb_encore_explicit, 
-            recording_numb_encore_instrumental]
-
-        mbids = ['daccb724-8023-432a-854c-e0accb6c8678', '965b75df-397d-4395-aac8-de11854c4630']
-        recordings = mb_recording.fetch_multiple_recordings(mbids, includes=['artists'])
-
-        self.assertDictEqual(recordings,
-            {
-                'daccb724-8023-432a-854c-e0accb6c8678': 
+            },
+            'ae83579c-5f33-4a35-83f3-89206c44a426': {
+                'id': 'ae83579c-5f33-4a35-83f3-89206c44a426',
+                'name': "I'm a Stranger Here Myself",
+                'length': 344.0,
+                'artist-credit-phrase': 'Charlie Byrd & The Washington Guitar Quintet',
+                'artists': [
                     {
-                        'id': 'daccb724-8023-432a-854c-e0accb6c8678',
-                        'name': 'Numb/Encore (explicit)',
-                        'length': 205.28,
-                        'artist-credit-phrase': 'Jay-Z/Linkin Park',
-                        'artists':
-                            [
-                                {'id': 'f82bcf78-5b69-4622-a5ef-73800768d9ac',
-                                    'name': 'JAY Z', 'credited_name': 'Jay-Z',
-                                    'join_phrase': '/'
-                                },
-                                {
-                                    'id': 'f59c5520-5f46-4d2c-b2c4-822eabf53419',
-                                    'name': 'Linkin Park'
-                                }
-                            ]
+                        'id': '9d99c378-247c-47a3-94ea-753efa330023',
+                        'name': 'Charlie Byrd',
+                        'join_phrase': ' & '
                     },
-                '965b75df-397d-4395-aac8-de11854c4630':
                     {
-                        'id': '965b75df-397d-4395-aac8-de11854c4630',
-                        'name': 'Numb/Encore (instrumental)',
-                        'length': 207.333,
-                        'artist-credit-phrase': 'Jay-Z/Linkin Park',
-                        'artists':
-                            [
-                                {
-                                    'id': 'f82bcf78-5b69-4622-a5ef-73800768d9ac',
-                                    'name': 'JAY Z',
-                                    'credited_name': 'Jay-Z',
-                                    'join_phrase': '/'
-                                },
-                                {
-                                    'id': 'f59c5520-5f46-4d2c-b2c4-822eabf53419',
-                                    'name': 'Linkin Park'
-                                }
-                            ]
+                        'id': 'c805fb7e-c8ff-49e0-b74f-61d638444fad',
+                        'name': 'The Washington Guitar Quintet'
                     }
+                ]
             }
-        )
+        }
 
-    def test_fetch_multiple_recordings_empty(self):
+    def test_fetch_multiple_recordings_empty(self, engine):
         """ Tests if appropriate recordings are returned for a given list of MBIDs. """
 
-        self.recording_query.return_value = []
-
-        mbids = ['daccb724-8023-432a-854c-e0accb6c8678', '965b75df-397d-4395-aac8-de11854c4630']
+        mbids = ['daccb724-8023-0000-0000-e0accb6c8678', '965b75df-397d-4395-aac8-de11854c4630']
         recordings = mb_recording.fetch_multiple_recordings(
             mbids,
             includes=['artists', 'url-rels', 'work-rels'],
             unknown_entities_for_missing=True
         )
 
-        self.assertEqual(recordings['daccb724-8023-432a-854c-e0accb6c8678']['name'], unknown_recording.name)
-        self.assertEqual(recordings['965b75df-397d-4395-aac8-de11854c4630']['name'], unknown_recording.name)
+        assert recordings['daccb724-8023-0000-0000-e0accb6c8678']['name'] == unknown_recording.name
+        assert recordings['965b75df-397d-4395-aac8-de11854c4630']['name'] == unknown_recording.name

--- a/brainzutils/musicbrainz_db/tests/test_recording.py
+++ b/brainzutils/musicbrainz_db/tests/test_recording.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 import pytest
 
 from brainzutils.musicbrainz_db import recording as mb_recording

--- a/brainzutils/musicbrainz_db/tests/test_release.py
+++ b/brainzutils/musicbrainz_db/tests/test_release.py
@@ -1,88 +1,129 @@
-from unittest import TestCase
-from mock import MagicMock
-from brainzutils.musicbrainz_db.unknown_entities import unknown_release
-from brainzutils.musicbrainz_db.test_data import (
-    recording_numb_encore_explicit,
-    release_numb_encore,
-    release_collision_course,
-    release_numb_encore_1,
-    release_blueprint,
-    release_the_hits_collection_volume_one_1,
-    release_the_hits_collection_volume_one_2
-)
+import pytest
+
 from brainzutils.musicbrainz_db import release as mb_release
+from brainzutils.musicbrainz_db.unknown_entities import unknown_release
 
 
-class ReleaseTestCase(TestCase):
+@pytest.mark.database
+class TestRelease:
 
-    def setUp(self):
-        mb_release.mb_session = MagicMock()
-        self.mock_db = mb_release.mb_session.return_value.__enter__.return_value
-        self.release_query = self.mock_db.query.return_value.options.return_value.options.return_value.\
-            options.return_value.options.return_value.options.return_value.filter.return_value.all
-
-    def test_get_by_id(self):
-        self.release_query.return_value = [release_numb_encore]
+    def test_get_by_id(self, engine):
         release = mb_release.get_release_by_id(
-            '16bee711-d7ce-48b0-adf4-51f124bcc0df',
+            'fed37cfc-2a6d-4569-9ac0-501a7c7598eb',
             includes=['media', 'release-groups'],
         )
-        self.assertEqual(release["name"], "Numb/Encore")
-        self.assertEqual(len(release["medium-list"][0]["track-list"]), 2)
-        self.assertDictEqual(release["medium-list"][0]["track-list"][0], {
-            "id": "dfe024b2-95b2-453f-b03e-3b9fa06f44e6",
-            "name": "Numb/Encore (explicit)",
-            "number": "1",
-            "position": 1,
-            "length": 207000,
-            "recording_id": "daccb724-8023-432a-854c-e0accb6c8678",
-            "recording_title": "Numb/Encore (explicit)"
-        })
+        assert release["name"] == "Master of Puppets"
+        assert len(release["medium-list"][0]["track-list"]) == 8
 
-    def test_fetch_multiple_releases(self):
-        self.mock_db.query.return_value.filter.return_value.all.return_value = [release_numb_encore_1, release_collision_course]
+        assert release["medium-list"][0]["track-list"] == [
+            {
+               "id":"58c97804-bd98-3bc6-b8c7-5234db05bc2e",
+               "name":"Battery",
+               "number":"1",
+               "position":1,
+               "length":312373,
+               "recording_id":"3bfda26a-49fa-4bc4-a4d6-8bbfa0767ab7",
+               "recording_title":"Battery"
+            },
+            {
+               "id":"51b179fa-8e72-383b-9549-0ae9a6dd9cfb",
+               "name":"Master of Puppets",
+               "number":"2",
+               "position":2,
+               "length":515226,
+               "recording_id":"0151d8a4-50c8-4036-b824-4a4f4b140e8e",
+               "recording_title":"Master of Puppets"
+            },
+            {
+               "id":"052e25d8-373e-3a5a-bced-bd47eb209dc5",
+               "name":"The Thing That Should Not Be",
+               "number":"3",
+               "position":3,
+               "length":396200,
+               "recording_id":"f5267fe1-5cb6-47f7-8df2-e6e8f09fa7ad",
+               "recording_title":"The Thing That Should Not Be"
+            },
+            {
+               "id":"00367246-d956-3a44-af4b-bc3cfd34ec49",
+               "name":"Welcome Home (Sanitarium)",
+               "number":"4",
+               "position":4,
+               "length":386866,
+               "recording_id":"a20860e9-7636-422b-a9cd-2da671b242a8",
+               "recording_title":"Welcome Home (Sanitarium)"
+            },
+            {
+               "id":"77fac948-8223-3077-a25e-50d9512142f0",
+               "name":"Disposable Heroes",
+               "number":"5",
+               "position":5,
+               "length":496640,
+               "recording_id":"93ae3251-d9b5-46ee-9849-7b16d5e57d8b",
+               "recording_title":"Disposable Heroes"
+            },
+            {
+               "id":"7f97a9e0-89ec-37ed-a3d7-5a7390ffa43b",
+               "name":"Leper Messiah",
+               "number":"6",
+               "position":6,
+               "length":339866,
+               "recording_id":"2d9a5b40-f5e6-4499-ab7a-567fe3b42ab9",
+               "recording_title":"Leper Messiah"
+            },
+            {
+               "id":"b7e772d3-3a9b-32ad-8e5c-e8c079d5e4f4",
+               "name":"Orion",
+               "number":"7",
+               "position":7,
+               "length":507426,
+               "recording_id":"b6cbe414-8b21-4600-8588-f6a80fd7043a",
+               "recording_title":"Orion"
+            },
+            {
+               "id":"0949ef68-edef-39a1-a3a0-dc666920f629",
+               "name":"Damage, Inc.",
+               "number":"8",
+               "position":8,
+               "length":330933,
+               "recording_id":"01ea1189-e0d2-48a0-9dc2-c615785a5ae0",
+               "recording_title":"Damage, Inc."
+            }
+        ]
+
+    def test_fetch_multiple_releases(self, engine):
         releases = mb_release.fetch_multiple_releases(
-            mbids=['f51598f5-4ef9-4b8a-865d-06a077bf78cf', 'a64a0467-9d7a-4ffa-90b8-d87d9b41e311'],
+            mbids=['e327da6d-717b-4eb3-b396-bbce6b9466bc', 'b1bb026c-e813-407f-ba7b-db7466cdc56c'],
         )
-        self.assertEqual(len(releases), 2)
-        self.assertEqual(releases['a64a0467-9d7a-4ffa-90b8-d87d9b41e311']['name'], 'Numb/Encore')
-        self.assertEqual(releases['f51598f5-4ef9-4b8a-865d-06a077bf78cf']['name'], 'Collision Course')
+        assert len(releases) == 2
+        assert releases['e327da6d-717b-4eb3-b396-bbce6b9466bc']['name'] == 'Without a Sound'
+        assert releases['b1bb026c-e813-407f-ba7b-db7466cdc56c']['name'] == 'War All the Time'
 
-    def test_fetch_multiple_releases_empty(self):
-        self.mock_db.query.return_value.filter.return_value.all.return_value = []
+    def test_fetch_multiple_releases_empty(self, engine):
         releases = mb_release.fetch_multiple_releases(
             mbids=['f51598f5-4ef9-4b8a-865d-06a077bf78cf', 'a64a0467-9d7a-4ffa-90b8-d87d9b41e311'],
             includes=['media', 'release-groups', 'url-rels'],
             unknown_entities_for_missing=True
         )
-        self.assertEqual(releases['a64a0467-9d7a-4ffa-90b8-d87d9b41e311']['name'], unknown_release.name)
-        self.assertEqual(releases['f51598f5-4ef9-4b8a-865d-06a077bf78cf']['name'], unknown_release.name)
+        assert releases['a64a0467-9d7a-4ffa-90b8-d87d9b41e311']['name'] == unknown_release.name
+        assert releases['f51598f5-4ef9-4b8a-865d-06a077bf78cf']['name'] == unknown_release.name
 
-    def test_get_releases_using_recording_mbid(self):
+    def test_get_releases_using_recording_mbid(self, engine):
         """Tests if releases are fetched correctly for a given recording MBID"""
-
-        mb_release.recording = MagicMock()
-        mb_release.recording.get_recording_by_mbid.return_value = {
-            'id': 'daccb724-8023-432a-854c-e0accb6c8678',
-            'name': 'Numb/Encore (explicit)',
-            'length': 205.28,
-        }
-
-        release_query = self.mock_db.query.return_value.join.return_value.join.return_value.join.return_value.\
-                        filter.return_value.all
-        release_query.return_value = [
-            release_the_hits_collection_volume_one_1,
-            release_blueprint,
-            release_the_hits_collection_volume_one_2,
-        ]
-
         releases = mb_release.get_releases_using_recording_mbid('5465ca86-3881-4349-81b2-6efbd3a59451')
-
-        mb_release.recording.get_recording_by_mbid.assert_called_once_with('5465ca86-3881-4349-81b2-6efbd3a59451')
-        release_query.assert_called_once()
-
-        self.assertListEqual(releases, [
+        assert releases == [
+            {'id': '89f64145-2f75-41d1-831a-517b785ed75a', 'name': "The Blueprint Collector's Edition"},
             {'id': 'f1183a86-36d2-4f1f-ab8f-6f965dc0b033', 'name': 'The Hits Collection Volume One'},
+            {'id': '77a74b85-0ae0-338f-aaca-4f36cd394f88', 'name': 'Blueprint 2.1'},
             {'id': '7111c8bc-8549-4abc-8ab9-db13f65b4a55', 'name': 'Blueprint 2.1'},
+            {'id': '2c5e4198-24cf-3c95-a16e-83be8e877dfa', 'name': 'The Blueprint²: The Gift & The Curse'},
             {'id': '3c535d03-2fcc-467a-8d47-34b3250b8211', 'name': 'The Hits Collection Volume One'},
-        ])
+            {'id': 'c84d8fa8-6f8d-42c9-87cc-b726e859b41d', 'name': 'The Hits Collection Volume One'},
+            {'id': '4f41108c-db36-4616-8614-f504fdef287a', 'name': 'Blueprint 2.1'},
+            {'id': 'b0075ce9-58c8-47e2-8a72-5f783314a97e', 'name': 'The Hits Collection Volume One'},
+            {'id': 'd75e103c-5ef4-4146-ae81-e27d19dc7fc4', 'name': "The Blueprint Collector's Edition"},
+            {'id': '4a441628-2e4d-4032-825f-6bdf4aee382e', 'name': 'The Hits Collection, Volume 1'},
+            {'id': '5e782ae3-602b-48b7-99be-de6bcffa4aba', 'name': 'The Hits Collection, Volume 1'},
+            {'id': '7ebaaa95-e316-3b20-8819-7e4ca648c135', 'name': 'The Hits Collection, Volume 1'},
+            {'id': '0ff452e3-c306-4082-b0dc-223725f4fbbf', 'name': 'The Blueprint²: The Gift & The Curse'},
+            {'id': '801678aa-5d30-4342-8227-e9618f164cca', 'name': 'The Blueprint²: The Gift & The Curse'}
+        ]

--- a/brainzutils/musicbrainz_db/tests/test_release.py
+++ b/brainzutils/musicbrainz_db/tests/test_release.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 import pytest
 
 from brainzutils.musicbrainz_db import release as mb_release

--- a/brainzutils/musicbrainz_db/tests/test_release_group.py
+++ b/brainzutils/musicbrainz_db/tests/test_release_group.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 import pytest
 
 from brainzutils.musicbrainz_db import release_group as mb_release_group

--- a/brainzutils/musicbrainz_db/tests/test_release_group.py
+++ b/brainzutils/musicbrainz_db/tests/test_release_group.py
@@ -1,90 +1,56 @@
-from unittest import TestCase
-from mock import MagicMock
+import pytest
+
 from brainzutils.musicbrainz_db import release_group as mb_release_group
 from brainzutils.musicbrainz_db.unknown_entities import unknown_release_group
-from brainzutils.musicbrainz_db.test_data import releasegroup_numb_encore, releasegroup_collision_course
 
 
-class ReleaseGroupTestCase(TestCase):
+@pytest.mark.database
+class TestReleaseGroup:
 
-    def setUp(self):
-        mb_release_group.mb_session = MagicMock()
-        self.mock_db = mb_release_group.mb_session.return_value.__enter__.return_value
-        # Mock sql query for fetching release groups and alter the return value to return SQLAlchemy objects.
-        self._release_group_query = self.mock_db.query.return_value.options.return_value.options.return_value
-        self._release_group_query_with_artists = self._release_group_query.options.return_value.options.return_value.\
-            options.return_value
-        self.release_group_query = self._release_group_query.filter.return_value.all
-        self.release_group_query_with_artists = self._release_group_query_with_artists.filter.return_value.all
-
-    def test_get_by_id(self):
-        self.release_group_query_with_artists.return_value = [releasegroup_numb_encore]
+    def test_get_by_id(self, engine):
         release_group = mb_release_group.get_release_group_by_id(
-            '7c1014eb-454c-3867-8854-3c95d265f8de',
+            '0f18ec88-aa87-38a9-8a65-f03d81763560',
             includes=['artists', 'releases', 'release-group-rels', 'url-rels', 'tags']
         )
 
-        self.assertEqual(release_group['id'], '7c1014eb-454c-3867-8854-3c95d265f8de')
-        self.assertEqual(release_group['title'], 'Numb/Encore')
+        assert release_group['id'] == '0f18ec88-aa87-38a9-8a65-f03d81763560'
+        assert release_group['title'] == 'Led Zeppelin'
         # Check if multiple artists are properly fetched
-        self.assertEqual(release_group['artist-credit-phrase'], 'Jay-Z/Linkin Park')
-        self.assertDictEqual(release_group['artist-credit'][0], {
-            'name': 'Jay-Z',
+        assert release_group['artist-credit-phrase'] == 'Led Zeppelin'
+        assert release_group['artist-credit'][0] == {
+            'name': 'Led Zeppelin',
             'artist': {
-                'id': 'f82bcf78-5b69-4622-a5ef-73800768d9ac',
-                'name': 'JAY Z',
-                'sort_name': 'JAY Z'
-            },
-            'join_phrase': '/',
-        })
-        self.assertDictEqual(release_group['artist-credit'][1], {
-            'name': 'Linkin Park',
-            'artist': {
-                'id': 'f59c5520-5f46-4d2c-b2c4-822eabf53419',
-                'name': 'Linkin Park',
-                'sort_name': 'Linkin Park',
-            },
-        })
+                'id': '678d88b2-87b0-403b-b63d-5da7465aecc3',
+                'name': 'Led Zeppelin',
+                'sort_name': 'Led Zeppelin'
+            }
+        }
 
-    def test_fetch_release_groups(self):
-        self.release_group_query.return_value = [releasegroup_numb_encore, releasegroup_collision_course]
+    def test_fetch_release_groups(self, engine):
         release_groups = mb_release_group.fetch_multiple_release_groups(
-            mbids=['8ef859e3-feb2-4dd1-93da-22b91280d768', '7c1014eb-454c-3867-8854-3c95d265f8de'],
+            mbids=['0f18ec88-aa87-38a9-8a65-f03d81763560', '1b36a363-eec6-35ba-b0ed-34a1f2f2cd82'],
         )
-        self.assertEqual(len(release_groups), 2)
-        self.assertEqual(release_groups['7c1014eb-454c-3867-8854-3c95d265f8de']['title'], 'Numb/Encore')
-        self.assertEqual(release_groups['8ef859e3-feb2-4dd1-93da-22b91280d768']['title'], 'Collision Course')
+        assert len(release_groups) == 2
+        assert release_groups['0f18ec88-aa87-38a9-8a65-f03d81763560']['title'] == 'Led Zeppelin'
+        assert release_groups['1b36a363-eec6-35ba-b0ed-34a1f2f2cd82']['title'] == 'Cosmic Thing'
 
-    def test_fetch_release_groups_empty(self):
-        self.release_group_query.return_value = []
+    def test_fetch_release_groups_empty(self, engine):
         release_groups = mb_release_group.fetch_multiple_release_groups(
             mbids=['8ef859e3-feb2-4dd1-93da-22b91280d768', '7c1014eb-454c-3867-8854-3c95d265f8de'],
             includes=['artists', 'releases', 'release-group-rels', 'url-rels', 'work-rels', 'tags'],
             unknown_entities_for_missing=True
         )
-        self.assertEqual(release_groups['7c1014eb-454c-3867-8854-3c95d265f8de']['title'], unknown_release_group.name)
-        self.assertEqual(release_groups['8ef859e3-feb2-4dd1-93da-22b91280d768']['title'], unknown_release_group.name)
+        assert release_groups['7c1014eb-454c-3867-8854-3c95d265f8de']['title'] == unknown_release_group.name
+        assert release_groups['8ef859e3-feb2-4dd1-93da-22b91280d768']['title'] == unknown_release_group.name
 
-    def test_fetch_get_release_groups_for_artist(self):
-        mb_release_group._get_release_groups_for_artist_query = MagicMock()
-        mock_query = mb_release_group._get_release_groups_for_artist_query.return_value
-        mock_query.count.return_value = 2
-        mock_query.order_by.return_value.limit.return_value.offset.\
-            return_value.all.return_value = [releasegroup_collision_course, releasegroup_numb_encore]
+    def test_fetch_get_release_groups_for_artist(self, engine):
         release_groups = mb_release_group.get_release_groups_for_artist(
             artist_id='f59c5520-5f46-4d2c-b2c4-822eabf53419',
             release_types=['Single', 'EP'],
         )
-        self.assertListEqual(release_groups[0], [
-            {
-                'id': '8ef859e3-feb2-4dd1-93da-22b91280d768',
-                'title': 'Collision Course',
-                'first-release-year': 2004,
-            },
-            {
-                'id': '7c1014eb-454c-3867-8854-3c95d265f8de',
-                'title': 'Numb/Encore',
-                'first-release-year': 2004,
-            }
-        ])
-        self.assertEqual(release_groups[1], 2)
+        assert release_groups[0] == [{
+            'id': '277ddbc8-d6fa-47fa-b652-dce7a325202f',
+            'title': 'A Thousand Suns: Puerta de Alcalá',
+            'first-release-year': 2010
+        }]
+        assert release_groups[1] == 1

--- a/brainzutils/musicbrainz_db/tests/test_work.py
+++ b/brainzutils/musicbrainz_db/tests/test_work.py
@@ -1,50 +1,42 @@
-from unittest import TestCase
-from mock import MagicMock
-from brainzutils.musicbrainz_db.test_data import work_a_lot, work_aquemini
+import pytest
+
 from brainzutils.musicbrainz_db.unknown_entities import unknown_work
 from brainzutils.musicbrainz_db import work as mb_work
 
 
-class WorkTestCase(TestCase):
-
-    def setUp(self):
-        mb_work.mb_session = MagicMock()
-        self.mock_db = mb_work.mb_session.return_value.__enter__.return_value
-        self.work_query = self.mock_db.query.return_value.options.return_value.filter.return_value.all
+@pytest.mark.database
+class TestWork:
 
     def test_get_work_by_id(self):
-        self.work_query.return_value = [work_a_lot]
-        work = mb_work.get_work_by_id('54ce5e07-2aca-4578-83d8-5a41a7b2f434')
-        self.assertDictEqual(work, {
-            "id": "54ce5e07-2aca-4578-83d8-5a41a7b2f434",
-            "name": "a lot",
+        work = mb_work.get_work_by_id('d35f8fb8-52ab-4a12-b1c8-f2054d10cf88')
+        assert work == {
+            "id": "d35f8fb8-52ab-4a12-b1c8-f2054d10cf88",
+            "name": "Apple Bush",
             "type": "Song",
-        })
+        }
 
     def test_fetch_multiple_works(self):
-        self.work_query.return_value = [work_a_lot, work_aquemini]
         works = mb_work.fetch_multiple_works([
-            '54ce5e07-2aca-4578-83d8-5a41a7b2f434',
-            '757504fb-a130-4b84-9eb5-1b37164f12dd'
+            'd35f8fb8-52ab-4a12-b1c8-f2054d10cf88',
+            '1deb7377-f980-4adb-8f0f-a36355461f38'
         ])
-        self.assertDictEqual(works["54ce5e07-2aca-4578-83d8-5a41a7b2f434"], {
-            "id": "54ce5e07-2aca-4578-83d8-5a41a7b2f434",
-            "name": "a lot",
+        assert works["d35f8fb8-52ab-4a12-b1c8-f2054d10cf88"] == {
+            "id": "d35f8fb8-52ab-4a12-b1c8-f2054d10cf88",
+            "name": "Apple Bush",
             "type": "Song",
-        })
-        self.assertDictEqual(works["757504fb-a130-4b84-9eb5-1b37164f12dd"], {
-            "id": "757504fb-a130-4b84-9eb5-1b37164f12dd",
-            "name": "Aquemini",
+        }
+        assert works["1deb7377-f980-4adb-8f0f-a36355461f38"] == {
+            "id": "1deb7377-f980-4adb-8f0f-a36355461f38",
+            "name": "Fields of Regret",
             "type": "Song",
-        })
+        }
 
     def test_fetch_multiple_works_empty(self):
-        self.work_query.return_value = []
         works = mb_work.fetch_multiple_works([
             '54ce5e07-2aca-4578-83d8-5a41a7b2f434',
             '757504fb-a130-4b84-9eb5-1b37164f12dd'
         ],
-        includes=['artist-rels', 'recording-rels'],
-        unknown_entities_for_missing=True)
-        self.assertEqual(works["54ce5e07-2aca-4578-83d8-5a41a7b2f434"]["name"], unknown_work.name)
-        self.assertEqual(works["757504fb-a130-4b84-9eb5-1b37164f12dd"]["name"], unknown_work.name)
+            includes=['artist-rels', 'recording-rels'],
+            unknown_entities_for_missing=True)
+        assert works["54ce5e07-2aca-4578-83d8-5a41a7b2f434"]["name"] == unknown_work.name
+        assert works["757504fb-a130-4b84-9eb5-1b37164f12dd"]["name"] == unknown_work.name

--- a/conftest.py
+++ b/conftest.py
@@ -1,8 +1,13 @@
 import pytest
 
-from brainzutils.musicbrainz_db import init_db_engine
+from brainzutils.musicbrainz_db import init_db_engine, mb_session
 
 
 @pytest.fixture(scope="session")
 def engine():
     init_db_engine("postgresql://musicbrainz@musicbrainz_db/musicbrainz_db")
+
+
+@pytest.fixture(scope="function")
+def session(engine):
+    return mb_session()

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,8 @@
+import pytest
+
+from brainzutils.musicbrainz_db import init_db_engine
+
+
+@pytest.fixture(scope="session")
+def engine():
+    init_db_engine("postgresql://musicbrainz@musicbrainz_db/musicbrainz_db")

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,6 @@
 [pytest]
 testpaths = brainzutils
 addopts = --cov-report html --cov=brainzutils
+
+markers =
+    database: requires access to the musicbrainz sample database

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ requests==2.23.0
 SQLAlchemy==1.3.16
 mbdata==25.0.4
 sqlalchemy-dst==1.0.1
+psycopg2-binary==2.8.6

--- a/test/Dockerfile.py3
+++ b/test/Dockerfile.py3
@@ -23,5 +23,6 @@ COPY . /code/
 ENV REDIS_HOST "redis"
 
 CMD dockerize -wait tcp://redis:6379 -timeout 10s \
+    dockerize -wait tcp://musicbrainz_db:5432 -timeout 600s \
     py.test --junitxml=/data/test_report.xml \
             --cov-report xml:/data/coverage.xml

--- a/test/docker-compose.db.yml
+++ b/test/docker-compose.db.yml
@@ -1,0 +1,26 @@
+version: "2"
+services:
+
+  test:
+    build:
+      context: ..
+      dockerfile: ./test/Dockerfile.py3
+    volumes:
+      - ../:/code
+    depends_on:
+      - redis
+      - musicbrainz_db
+
+  redis:
+    image: redis:3.2.1
+
+  musicbrainz_db:
+    build:
+      context: musicbrainz_db
+      dockerfile: Dockerfile
+    environment:
+      PGDATA: /var/lib/postgresql/data/pgdata
+      POSTGRES_HOST_AUTH_METHOD: trust
+      WGET_OPTIONS: -q
+    ports:
+      - "5430:5432"

--- a/test/musicbrainz_db/Dockerfile
+++ b/test/musicbrainz_db/Dockerfile
@@ -1,0 +1,13 @@
+FROM metabrainz/musicbrainz-test-database:beta
+
+RUN apt-get update && apt-get install -y wget
+
+RUN mkdir /home/musicbrainz/musicbrainz-server/setup_db
+COPY scripts/* /home/musicbrainz/musicbrainz-server/setup_db/
+RUN chmod +x /home/musicbrainz/musicbrainz-server/setup_db/*
+
+RUN mkdir -p /media/dbdump
+RUN chown postgres /media/dbdump
+
+RUN rm -f /docker-entrypoint-initdb.d/create_test_db.sh
+RUN ln -s /home/musicbrainz/musicbrainz-server/setup_db/create_test_db.sh /docker-entrypoint-initdb.d/

--- a/test/musicbrainz_db/scripts/create_test_db.sh
+++ b/test/musicbrainz_db/scripts/create_test_db.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+# During the entrypoint stage, postgres is only listening on a socket
+# force it to listen on localhost in order to perform the data load
+pg_ctl -o "-c listen_addresses='localhost'" -w restart
+
+cd /home/musicbrainz/musicbrainz-server
+carton exec -- ./setup_db/createdb.sh -sample -fetch

--- a/test/musicbrainz_db/scripts/createdb.sh
+++ b/test/musicbrainz_db/scripts/createdb.sh
@@ -1,0 +1,94 @@
+#!/bin/bash
+
+set -e -o pipefail -u
+
+FTP_MB=ftp://ftp.eu.metabrainz.org/pub/musicbrainz
+IMPORT="fullexport"
+FETCH_DUMPS=""
+WGET_OPTIONS=""
+
+HELP=$(cat <<EOH
+Usage: $0 [-wget-opts <options list>] [-sample] [-fetch] [MUSICBRAINZ_FTP_URL]
+
+Options:
+  -fetch      Fetch latest dump from MusicBrainz FTP
+  -sample     Load sample data instead of full data
+  -wget-opts  Pass additional space-separated options list (should be
+              a single argument, escape spaces if necessary) to wget
+
+Default MusicBrainz FTP URL: $FTP_MB
+EOH
+)
+
+if [ $# -gt 4 ]; then
+    echo "$0: too many arguments"
+    echo "$HELP"
+    exit 1
+fi
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        -wget-opts )
+            shift
+            WGET_OPTIONS=$1
+            ;;
+        -sample )
+            IMPORT="sample"
+            ;;
+        -fetch  )
+            FETCH_DUMPS="$1"
+            ;;
+        -*      )
+            echo "$0: unrecognized option '$1'"
+            echo "$HELP"
+            exit 1
+            ;;
+        *       )
+            FTP_MB="$1"
+            ;;
+    esac
+    shift
+done
+
+TMP_DIR=/media/dbdump/tmp
+
+case "$IMPORT" in
+    fullexport  )
+        DUMP_FILES=(
+            mbdump.tar.bz2
+            mbdump-cdstubs.tar.bz2
+            mbdump-cover-art-archive.tar.bz2
+            mbdump-derived.tar.bz2
+            mbdump-stats.tar.bz2
+            mbdump-wikidocs.tar.bz2
+        );;
+    sample      )
+        DUMP_FILES=(
+            mbdump-sample.tar.xz
+        );;
+esac
+
+if [[ $FETCH_DUMPS == "-fetch" ]]; then
+    FETCH_OPTIONS=("${IMPORT/fullexport/replica}" --base-ftp-url "$FTP_MB")
+    if [[ -n "$WGET_OPTIONS" ]]; then
+        FETCH_OPTIONS+=(--wget-options "$WGET_OPTIONS")
+    fi
+    `dirname "$0"`/fetch-dump.sh "${FETCH_OPTIONS[@]}"
+fi
+
+if [[ -a /media/dbdump/"${DUMP_FILES[0]}" ]]; then
+    echo "found existing dumps"
+
+    mkdir -p $TMP_DIR
+    #cd /media/dbdump
+
+    INITDB_OPTIONS='--echo --import'
+    if ! /home/musicbrainz/musicbrainz-server/script/database_exists MAINTENANCE; then
+        INITDB_OPTIONS="--createdb $INITDB_OPTIONS"
+    fi
+    # shellcheck disable=SC2086
+    ./admin/InitDb.pl --createdb --database READWRITE --import /media/dbdump/mbdump*.tar.xz --echo
+    #/home/musicbrainz/musicbrainz-server/admin/InitDb.pl $INITDB_OPTIONS -- --skip-editor --tmp-dir $TMP_DIR "${DUMP_FILES[@]}"
+else
+    echo "no dumps found or dumps are incomplete"
+fi

--- a/test/musicbrainz_db/scripts/fetch-dump.sh
+++ b/test/musicbrainz_db/scripts/fetch-dump.sh
@@ -1,0 +1,183 @@
+#!/usr/bin/env bash
+
+set -e -o pipefail -u
+
+DB_DUMP_DIR=/media/dbdump
+SEARCH_DUMP_DIR=/media/searchdump
+BASE_FTP_URL='ftp://ftp.eu.metabrainz.org/pub/musicbrainz'
+TARGET=''
+WGET_CMD=(wget)
+
+SCRIPT_NAME=$(basename "$0")
+HELP=$(cat <<EOH
+Usage: $SCRIPT_NAME [<options>] <target>
+
+Fetch dump files of the MusicBrainz database and/or search indexes.
+
+Targets:
+  both          Fetch latest search dump with replica dump of the same day.
+  replica       Fetch latest database's replicated tables only.
+  sample        Fetch latest database's sample only.
+  search        Fetch latest search indexes only.
+
+Options:
+  --base-ftp-url <url>          Specify URL to MetaBrainz/MusicBrainz FTP directory.
+                                (Default: '$BASE_FTP_URL')
+  --wget-options <wget options> Specify additional options to be passed to wget,
+                                these should be separated with whitespace,
+                                the list should be a single argument
+                                (escape whitespaces if needed).
+
+  -h, --help                    Print this help message.
+EOH
+)
+
+# Parse arguments
+
+while [[ $# -gt 0 ]]
+do
+	case "$1" in
+		both | replica | sample | search )
+			if [[ -n $TARGET ]]
+			then
+				echo >&2 "$SCRIPT_NAME: only one target argument can be given"
+				echo >&2 "Try '$SCRIPT_NAME --help' for usage."
+				exit 64 # EX_USAGE
+			fi
+			TARGET=$1
+			;;
+		--base-ftp-url )
+			shift
+			BASE_FTP_URL="$1"
+			;;
+		--wget-options )
+			shift
+			IFS=' ' read -r -a WGET_OPTIONS <<< "$1"
+			WGET_CMD+=("${WGET_OPTIONS[@]}")
+			unset WGET_OPTIONS
+			;;
+		-h | --help )
+			echo "$HELP"
+			exit 0 # EX_OK
+			;;
+		-* )
+			echo >&2 "$SCRIPT_NAME: unrecognized option '$1'"
+			echo >&2 "Try '$SCRIPT_NAME --help' for usage."
+			exit 64 # EX_USAGE
+			;;
+		* )
+			echo >&2 "$SCRIPT_NAME: unrecognized argument '$1'"
+			echo >&2 "Try '$SCRIPT_NAME --help' for usage."
+			exit 64 # EX_USAGE
+			;;
+	esac
+	shift
+done
+
+if [[ -z $TARGET ]]
+then
+	echo >&2 "$SCRIPT_NAME: no dump type has been specified"
+	echo >&2 "Try '$SCRIPT_NAME --help' for usage."
+	exit 64 # EX_USAGE
+fi
+
+# Fetch latest search indexes
+
+if [[ $TARGET =~ ^(both|search)$ ]]
+then
+	echo "$(date): Fetching search indexes dump..."
+	cd "$SEARCH_DUMP_DIR" && find . -delete && cd -
+	"${WGET_CMD[@]}" -nd -nH -P "$SEARCH_DUMP_DIR" \
+		"$BASE_FTP_URL/data/search-indexes/LATEST"
+	DUMP_TIMESTAMP=$(cat /media/searchdump/LATEST)
+	"${WGET_CMD[@]}" -nd -nH -r -P "$SEARCH_DUMP_DIR" \
+		"$BASE_FTP_URL/data/search-indexes/$DUMP_TIMESTAMP/"
+	cd "$SEARCH_DUMP_DIR" && md5sum -c MD5SUMS && cd -
+	if [[ $TARGET == search ]]
+	then
+		echo 'Done fetching search indexes dump'
+		exit 0 # EX_OK
+	fi
+fi
+
+# Prepare to fetch database dump
+
+if [[ $TARGET != search ]]
+then
+	echo "$(date): Fetching database dump..."
+
+	rm -rf "${DB_DUMP_DIR:?}"/*
+fi
+
+case "$TARGET" in
+	both | replica )
+		DB_DUMP_REMOTE_DIR=data/fullexport
+		DB_DUMP_FILES=(
+			mbdump.tar.bz2
+			mbdump-cdstubs.tar.bz2
+			mbdump-cover-art-archive.tar.bz2
+			mbdump-derived.tar.bz2
+			mbdump-stats.tar.bz2
+			mbdump-wikidocs.tar.bz2
+		)
+		;;
+	sample )
+		DB_DUMP_REMOTE_DIR=data/sample
+		DB_DUMP_FILES=(
+			mbdump-sample.tar.xz
+		)
+		;;
+esac
+
+if [[ $TARGET == both ]]
+then
+	# Find latest database dump corresponding to search indexes
+
+	SEARCH_DUMP_DAY="${DUMP_TIMESTAMP/-*}"
+	"${WGET_CMD[@]}" --spider --no-remove-listing -P "$DB_DUMP_DIR" \
+		"$BASE_FTP_URL/$DB_DUMP_REMOTE_DIR"
+	DUMP_TIMESTAMP=$(
+		grep -E "\\s${SEARCH_DUMP_DAY}-\\d*" "$DB_DUMP_DIR/.listing" \
+			| sed -e 's/\s*$//' -e 's/.*\s//'
+	)
+	rm -f "$DB_DUMP_DIR/.listing"
+	echo "$DUMP_TIMESTAMP" >> "$DB_DUMP_DIR/LATEST-WITH-SEARCH-INDEXES"
+elif [[ $TARGET != search ]]
+then
+	# Just find latest database dump
+
+	"${WGET_CMD[@]}" -nd -nH -P "$DB_DUMP_DIR" \
+		"$BASE_FTP_URL/$DB_DUMP_REMOTE_DIR/LATEST"
+	DUMP_TIMESTAMP=$(cat /media/dbdump/LATEST)
+fi
+
+# Actually fetch database dump
+
+if [[ $TARGET =~ ^(both|replica)$ ]]
+then
+	for F in MD5SUMS "${DB_DUMP_FILES[@]}"
+	do
+		"${WGET_CMD[@]}" -P "$DB_DUMP_DIR" \
+			"$BASE_FTP_URL/$DB_DUMP_REMOTE_DIR/$DUMP_TIMESTAMP/$F"
+	done
+	cd "$DB_DUMP_DIR"
+	for F in "${DB_DUMP_FILES[@]}"
+	do
+		MD5SUM=$(md5sum -b "$F")
+		grep -Fqx "$MD5SUM" MD5SUMS || {
+			echo >&2 "$0: unmatched MD5 checksum: $MD5SUM *$F" &&
+			exit 70 # EX_SOFTWARE
+		}
+	done
+	cd -
+elif [[ $TARGET == sample ]]
+then
+	for F in "${DB_DUMP_FILES[@]}"
+	do
+		"${WGET_CMD[@]}" -P "$DB_DUMP_DIR" \
+			"$BASE_FTP_URL/$DB_DUMP_REMOTE_DIR/$DUMP_TIMESTAMP/$F"
+	done
+fi
+
+echo "$(date): Done fetching dump files."
+# vi: set noexpandtab softtabstop=0:


### PR DESCRIPTION
We found some errors in the musicbrainz_db module due to the mocks in the tests not accurately reflecting what is actually returned by a query: https://github.com/metabrainz/brainzutils-python/blame/a73309306697cd08bc4d0bad2e296cc61c993713/brainzutils/musicbrainz_db/utils.py#L80-L87

This is an experimental setup to include a copy of the musicbrainz sample database, and use it when running tests that use mbdata.

Currently, a multi-step process. To build, 

    $ docker-compose -f docker-compose.db.yml build
    $ docker-compose -f docker-compose.db.yml run --rm test bash
    # pytest -m database

some inline comments in the PR

cc @amCap1712 