### PR TITLE
Don't install psycopg2 in requirements/dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,4 +11,3 @@ requests>=2.23.0
 SQLAlchemy>=1.3.16
 mbdata==25.0.4
 sqlalchemy-dst>=1.0.1
-psycopg2-binary>=2.8.6


### PR DESCRIPTION
Allow downstream packages to set their own version. Only install it
in BU during testing