### PR TITLE
BU-41: Enforce cache timeouts

### DIFF
--- a/brainzutils/cache.py
+++ b/brainzutils/cache.py
@@ -93,13 +93,13 @@ def init_required(f):
 
 # pylint: disable=redefined-builtin
 @init_required
-def set(key, val, time, namespace=None, encode=True):
+def set(key, val, expirein, namespace=None, encode=True):
     """Set a key to a given value.
 
     Args:
         key (str): Key of the item.
         val: Item's value.
-        time (int): The time after which this value should expire, in seconds.
+        expirein (int): The time after which this value should expire, in seconds.
         namespace (str): Optional namespace in which key needs to be defined.
         encode: True if the value should be encoded with msgpack, False otherwise
 
@@ -109,7 +109,7 @@ def set(key, val, time, namespace=None, encode=True):
     # Note that both key and value are encoded before insertion.
     return set_many(
         mapping={key: val},
-        time=time,
+        expirein=expirein,
         namespace=namespace,
         encode=encode
     )
@@ -147,19 +147,19 @@ def delete(key, namespace=None):
 
 
 @init_required
-def expire(key, time, namespace=None):
+def expire(key, expirein, namespace=None):
     """Set the expiration time for an item
 
     Args:
         key: Key of the item that needs to be deleted.
-        time: the number of seconds after which the item should expire
+        expirein: the number of seconds after which the item should expire
         namespace: Optional namespace in which key was defined.
 
     Returns:
           True if the timeout was set, False otherwise
     """
     # Note that key is encoded before deletion request.
-    return _r.pexpire(_prep_key(key, namespace), time * 1000)
+    return _r.pexpire(_prep_key(key, namespace), expirein * 1000)
 
 
 @init_required
@@ -179,12 +179,12 @@ def expireat(key, timeat, namespace=None):
 
 
 @init_required
-def set_many(mapping, time, namespace=None, encode=True):
+def set_many(mapping, expirein, namespace=None, encode=True):
     """Set multiple keys doing just one query.
 
     Args:
         mapping (dict): A dict of key/value pairs to set.
-        time (int): The time after which this value should expire, in seconds.
+        expirein (int): The time after which this value should expire, in seconds.
         namespace (str): Namespace for the keys.
         encode: True if the values should be encoded with msgpack, False otherwise
 
@@ -193,9 +193,9 @@ def set_many(mapping, time, namespace=None, encode=True):
     """
     # TODO: Fix return value
     result = _r.mset(_prep_dict(mapping, namespace, encode))
-    if time:
+    if expirein:
         for key in _prep_keys_list(list(mapping.keys()), namespace):
-            _r.pexpire(key, time * 1000)
+            _r.pexpire(key, expirein * 1000)
 
     return result
 

--- a/brainzutils/cache.py
+++ b/brainzutils/cache.py
@@ -93,7 +93,7 @@ def init_required(f):
 
 # pylint: disable=redefined-builtin
 @init_required
-def set(key, val, time=0, namespace=None, encode=True):
+def set(key, val, time, namespace=None, encode=True):
     """Set a key to a given value.
 
     Args:
@@ -179,7 +179,7 @@ def expireat(key, timeat, namespace=None):
 
 
 @init_required
-def set_many(mapping, time=None, namespace=None, encode=True):
+def set_many(mapping, time, namespace=None, encode=True):
     """Set multiple keys doing just one query.
 
     Args:

--- a/brainzutils/ratelimit.py
+++ b/brainzutils/ratelimit.py
@@ -124,9 +124,9 @@ def set_rate_limits(per_token, per_ip, window):
     '''
         Update the current rate limits. This will affect all new rate limiting windows and existing windows will not be changed.
     '''
-    cache.set(ratelimit_per_token_key, per_token, time=0)
-    cache.set(ratelimit_per_ip_key, per_ip, time=0)
-    cache.set(ratelimit_window_key, window, time=0)
+    cache.set(ratelimit_per_token_key, per_token, expirein=0)
+    cache.set(ratelimit_per_ip_key, per_ip, expirein=0)
+    cache.set(ratelimit_window_key, window, expirein=0)
 
 
 def inject_x_rate_headers(response):
@@ -172,19 +172,19 @@ def check_limit_freshness():
 
     value = int(cache.get(ratelimit_per_token_key) or '0')
     if not value:
-        cache.set(ratelimit_per_token_key, ratelimit_per_token_default, time=0)
+        cache.set(ratelimit_per_token_key, ratelimit_per_token_default, expirein=0)
         value = ratelimit_per_token_default
     setattr(g, '_' + ratelimit_per_token_key, value)
 
     value = int(cache.get(ratelimit_per_ip_key) or '0')
     if not value:
-        cache.set(ratelimit_per_ip_key, ratelimit_per_ip_default, time=0)
+        cache.set(ratelimit_per_ip_key, ratelimit_per_ip_default, expirein=0)
         value = ratelimit_per_ip_default
     setattr(g, '_' + ratelimit_per_ip_key, value)
 
     value = int(cache.get(ratelimit_window_key) or '0')
     if not value:
-        cache.set(ratelimit_window_key, ratelimit_window_default, time=0)
+        cache.set(ratelimit_window_key, ratelimit_window_default, expirein=0)
         value = ratelimit_window_default
     setattr(g, '_' + ratelimit_window_key, value)
 

--- a/brainzutils/ratelimit.py
+++ b/brainzutils/ratelimit.py
@@ -124,9 +124,9 @@ def set_rate_limits(per_token, per_ip, window):
     '''
         Update the current rate limits. This will affect all new rate limiting windows and existing windows will not be changed.
     '''
-    cache.set(ratelimit_per_token_key, per_token)
-    cache.set(ratelimit_per_ip_key, per_ip)
-    cache.set(ratelimit_window_key, window)
+    cache.set(ratelimit_per_token_key, per_token, time=0)
+    cache.set(ratelimit_per_ip_key, per_ip, time=0)
+    cache.set(ratelimit_window_key, window, time=0)
 
 
 def inject_x_rate_headers(response):
@@ -172,19 +172,19 @@ def check_limit_freshness():
 
     value = int(cache.get(ratelimit_per_token_key) or '0')
     if not value:
-        cache.set(ratelimit_per_token_key, ratelimit_per_token_default)
+        cache.set(ratelimit_per_token_key, ratelimit_per_token_default, time=0)
         value = ratelimit_per_token_default
     setattr(g, '_' + ratelimit_per_token_key, value)
 
     value = int(cache.get(ratelimit_per_ip_key) or '0')
     if not value:
-        cache.set(ratelimit_per_ip_key, ratelimit_per_ip_default)
+        cache.set(ratelimit_per_ip_key, ratelimit_per_ip_default, time=0)
         value = ratelimit_per_ip_default
     setattr(g, '_' + ratelimit_per_ip_key, value)
 
     value = int(cache.get(ratelimit_window_key) or '0')
     if not value:
-        cache.set(ratelimit_window_key, ratelimit_window_default)
+        cache.set(ratelimit_window_key, ratelimit_window_default, time=0)
         value = ratelimit_window_default
     setattr(g, '_' + ratelimit_window_key, value)
 

--- a/brainzutils/test/test_cache.py
+++ b/brainzutils/test/test_cache.py
@@ -33,24 +33,24 @@ class CacheTestCase(unittest.TestCase):
     def test_no_init(self):
         cache._r = None
         with self.assertRaises(RuntimeError):
-            cache.set("test", "testing")
+            cache.set("test", "testing", time=0)
         with self.assertRaises(RuntimeError):
             cache.get("test")
 
     def test_single(self):
-        self.assertTrue(cache.set("test2", "Hello!"))
+        self.assertTrue(cache.set("test2", "Hello!", time=0))
         self.assertEqual(cache.get("test2"), "Hello!")
 
     def test_single_no_encode(self):
-        self.assertTrue(cache.set("no encode", 1, encode=False))
+        self.assertTrue(cache.set("no encode", 1, time=0, encode=False))
         self.assertEqual(cache.get("no encode", decode=False), b"1")
 
     def test_single_with_namespace(self):
-        self.assertTrue(cache.set("test", 42, namespace="testing"))
+        self.assertTrue(cache.set("test", 42, namespace="testing", time=0))
         self.assertEqual(cache.get("test", namespace="testing"), 42)
 
     def test_single_fancy(self):
-        self.assertTrue(cache.set("test3", u"Привет!"))
+        self.assertTrue(cache.set("test3", u"Привет!", time=0))
         self.assertEqual(cache.get("test3"), u"Привет!")
 
     def test_single_dict(self):
@@ -58,7 +58,7 @@ class CacheTestCase(unittest.TestCase):
             "fancy": "yeah",
             "wow": 11,
         }
-        self.assertTrue(cache.set('some_dict', dictionary))
+        self.assertTrue(cache.set('some_dict', dictionary, time=0))
         self.assertEqual(cache.get('some_dict'), dictionary)
 
     def test_single_dict_fancy(self):
@@ -66,23 +66,23 @@ class CacheTestCase(unittest.TestCase):
             "fancy": u"Да",
             "тест": 11,
         }
-        cache.set('some_dict', dictionary)
+        cache.set('some_dict', dictionary, time=0)
         self.assertEqual(cache.get('some_dict'), dictionary)
 
     def test_datetime(self):
-        self.assertTrue(cache.set('some_time', datetime.datetime.now()))
+        self.assertTrue(cache.set('some_time', datetime.datetime.now(), time=0))
         self.assertEqual(type(cache.get('some_time')), datetime.datetime)
 
         dictionary = {
             "id": 1,
             "created": datetime.datetime.now(),
         }
-        self.assertTrue(cache.set('some_other_time', dictionary))
+        self.assertTrue(cache.set('some_other_time', dictionary, time=0))
         self.assertEqual(cache.get('some_other_time'), dictionary)
 
     def test_delete(self):
         key = "testing"
-        self.assertTrue(cache.set(key, u"Пример"))
+        self.assertTrue(cache.set(key, u"Пример", time=0))
         self.assertEqual(cache.get(key), u"Пример")
         self.assertEqual(cache.delete(key), 1)
         self.assertIsNone(cache.get(key))
@@ -90,7 +90,7 @@ class CacheTestCase(unittest.TestCase):
     def test_delete_with_namespace(self):
         key = "testing"
         namespace = "spaaaaaaace"
-        self.assertTrue(cache.set(key, u"Пример", namespace=namespace))
+        self.assertTrue(cache.set(key, u"Пример", namespace=namespace, time=0))
         self.assertEqual(cache.get(key, namespace=namespace), u"Пример")
         self.assertEqual(cache.delete(key, namespace=namespace), 1)
         self.assertIsNone(cache.get(key, namespace=namespace))
@@ -101,7 +101,7 @@ class CacheTestCase(unittest.TestCase):
             "test1": "Hello",
             "test2": "there",
         }
-        self.assertTrue(cache.set_many(mapping, namespace="testing-1"))
+        self.assertTrue(cache.set_many(mapping, namespace="testing-1", time=0))
         self.assertEqual(cache.get_many(list(mapping.keys()), namespace="testing-1"), mapping)
 
         # With another namespace
@@ -115,7 +115,7 @@ class CacheTestCase(unittest.TestCase):
             "test1": "What's",
             "test2": "good",
         }
-        self.assertTrue(cache.set_many(mapping))
+        self.assertTrue(cache.set_many(mapping, time=0))
         self.assertEqual(cache.get_many(list(mapping.keys())), mapping)
 
     def test_invalidate_namespace(self):
@@ -142,23 +142,22 @@ class CacheTestCase(unittest.TestCase):
             cache.get_namespace_version("Hello!")
 
     def test_increment(self):
-        cache.set("a", 1, encode=False)
+        cache.set("a", 1, encode=False, time=0)
         self.assertEqual(cache.increment("a"), 2)
 
     def test_increment_invalid_value(self):
-        cache.set("a", "not a number")
+        cache.set("a", "not a number", time=0)
         with self.assertRaises(redis.exceptions.ResponseError):
             cache.increment("a")
 
     def test_expire(self):
-        cache.set("a", 1, time = 100)
+        cache.set("a", 1, time=100)
         self.assertEqual(cache.expire("a", 1), True)
         sleep(1.1)
         self.assertEqual(cache.get("a"), None)
 
-
     def test_expireat(self):
-        cache.set("a", 1, time = 100)
+        cache.set("a", 1, time=100)
         self.assertEqual(cache.expireat("a", int(time() + 1)), True)
         sleep(1.1)
         self.assertEqual(cache.get("a"), None)
@@ -171,7 +170,7 @@ class CacheKeyTestCase(unittest.TestCase):
     def test_set_key(self, mock_redis):
         """Test setting a bytes value"""
         cache.init(host='host', port=2, namespace=self.namespace)
-        cache.set('key', u'value'.encode('utf-8'))
+        cache.set('key', u'value'.encode('utf-8'), time=0)
 
         # Keys are encoded into bytes always
         expected_key = 'NS_TEST:key'.encode('utf-8')
@@ -184,7 +183,7 @@ class CacheKeyTestCase(unittest.TestCase):
     def test_set_key_unicode(self, mock_redis):
         """Test setting a unicode value"""
         cache.init(host='host', port=2, namespace=self.namespace)
-        cache.set('key', u'value')
+        cache.set('key', u'value', time=0)
 
         expected_key = 'NS_TEST:key'.encode('utf-8')
         # msgpack encoded value

--- a/brainzutils/test/test_cache.py
+++ b/brainzutils/test/test_cache.py
@@ -33,24 +33,24 @@ class CacheTestCase(unittest.TestCase):
     def test_no_init(self):
         cache._r = None
         with self.assertRaises(RuntimeError):
-            cache.set("test", "testing", time=0)
+            cache.set("test", "testing", expirein=0)
         with self.assertRaises(RuntimeError):
             cache.get("test")
 
     def test_single(self):
-        self.assertTrue(cache.set("test2", "Hello!", time=0))
+        self.assertTrue(cache.set("test2", "Hello!", expirein=0))
         self.assertEqual(cache.get("test2"), "Hello!")
 
     def test_single_no_encode(self):
-        self.assertTrue(cache.set("no encode", 1, time=0, encode=False))
+        self.assertTrue(cache.set("no encode", 1, expirein=0, encode=False))
         self.assertEqual(cache.get("no encode", decode=False), b"1")
 
     def test_single_with_namespace(self):
-        self.assertTrue(cache.set("test", 42, namespace="testing", time=0))
+        self.assertTrue(cache.set("test", 42, namespace="testing", expirein=0))
         self.assertEqual(cache.get("test", namespace="testing"), 42)
 
     def test_single_fancy(self):
-        self.assertTrue(cache.set("test3", u"Привет!", time=0))
+        self.assertTrue(cache.set("test3", u"Привет!", expirein=0))
         self.assertEqual(cache.get("test3"), u"Привет!")
 
     def test_single_dict(self):
@@ -58,7 +58,7 @@ class CacheTestCase(unittest.TestCase):
             "fancy": "yeah",
             "wow": 11,
         }
-        self.assertTrue(cache.set('some_dict', dictionary, time=0))
+        self.assertTrue(cache.set('some_dict', dictionary, expirein=0))
         self.assertEqual(cache.get('some_dict'), dictionary)
 
     def test_single_dict_fancy(self):
@@ -66,23 +66,23 @@ class CacheTestCase(unittest.TestCase):
             "fancy": u"Да",
             "тест": 11,
         }
-        cache.set('some_dict', dictionary, time=0)
+        cache.set('some_dict', dictionary, expirein=0)
         self.assertEqual(cache.get('some_dict'), dictionary)
 
     def test_datetime(self):
-        self.assertTrue(cache.set('some_time', datetime.datetime.now(), time=0))
+        self.assertTrue(cache.set('some_time', datetime.datetime.now(), expirein=0))
         self.assertEqual(type(cache.get('some_time')), datetime.datetime)
 
         dictionary = {
             "id": 1,
             "created": datetime.datetime.now(),
         }
-        self.assertTrue(cache.set('some_other_time', dictionary, time=0))
+        self.assertTrue(cache.set('some_other_time', dictionary, expirein=0))
         self.assertEqual(cache.get('some_other_time'), dictionary)
 
     def test_delete(self):
         key = "testing"
-        self.assertTrue(cache.set(key, u"Пример", time=0))
+        self.assertTrue(cache.set(key, u"Пример", expirein=0))
         self.assertEqual(cache.get(key), u"Пример")
         self.assertEqual(cache.delete(key), 1)
         self.assertIsNone(cache.get(key))
@@ -90,7 +90,7 @@ class CacheTestCase(unittest.TestCase):
     def test_delete_with_namespace(self):
         key = "testing"
         namespace = "spaaaaaaace"
-        self.assertTrue(cache.set(key, u"Пример", namespace=namespace, time=0))
+        self.assertTrue(cache.set(key, u"Пример", namespace=namespace, expirein=0))
         self.assertEqual(cache.get(key, namespace=namespace), u"Пример")
         self.assertEqual(cache.delete(key, namespace=namespace), 1)
         self.assertIsNone(cache.get(key, namespace=namespace))
@@ -101,7 +101,7 @@ class CacheTestCase(unittest.TestCase):
             "test1": "Hello",
             "test2": "there",
         }
-        self.assertTrue(cache.set_many(mapping, namespace="testing-1", time=0))
+        self.assertTrue(cache.set_many(mapping, namespace="testing-1", expirein=0))
         self.assertEqual(cache.get_many(list(mapping.keys()), namespace="testing-1"), mapping)
 
         # With another namespace
@@ -115,7 +115,7 @@ class CacheTestCase(unittest.TestCase):
             "test1": "What's",
             "test2": "good",
         }
-        self.assertTrue(cache.set_many(mapping, time=0))
+        self.assertTrue(cache.set_many(mapping, expirein=0))
         self.assertEqual(cache.get_many(list(mapping.keys())), mapping)
 
     def test_invalidate_namespace(self):
@@ -142,22 +142,22 @@ class CacheTestCase(unittest.TestCase):
             cache.get_namespace_version("Hello!")
 
     def test_increment(self):
-        cache.set("a", 1, encode=False, time=0)
+        cache.set("a", 1, encode=False, expirein=0)
         self.assertEqual(cache.increment("a"), 2)
 
     def test_increment_invalid_value(self):
-        cache.set("a", "not a number", time=0)
+        cache.set("a", "not a number", expirein=0)
         with self.assertRaises(redis.exceptions.ResponseError):
             cache.increment("a")
 
     def test_expire(self):
-        cache.set("a", 1, time=100)
+        cache.set("a", 1, expirein=100)
         self.assertEqual(cache.expire("a", 1), True)
         sleep(1.1)
         self.assertEqual(cache.get("a"), None)
 
     def test_expireat(self):
-        cache.set("a", 1, time=100)
+        cache.set("a", 1, expirein=100)
         self.assertEqual(cache.expireat("a", int(time() + 1)), True)
         sleep(1.1)
         self.assertEqual(cache.get("a"), None)
@@ -170,7 +170,7 @@ class CacheKeyTestCase(unittest.TestCase):
     def test_set_key(self, mock_redis):
         """Test setting a bytes value"""
         cache.init(host='host', port=2, namespace=self.namespace)
-        cache.set('key', u'value'.encode('utf-8'), time=0)
+        cache.set('key', u'value'.encode('utf-8'), expirein=0)
 
         # Keys are encoded into bytes always
         expected_key = 'NS_TEST:key'.encode('utf-8')
@@ -183,7 +183,7 @@ class CacheKeyTestCase(unittest.TestCase):
     def test_set_key_unicode(self, mock_redis):
         """Test setting a unicode value"""
         cache.init(host='host', port=2, namespace=self.namespace)
-        cache.set('key', u'value', time=0)
+        cache.set('key', u'value', expirein=0)
 
         expected_key = 'NS_TEST:key'.encode('utf-8')
         # msgpack encoded value
@@ -194,7 +194,7 @@ class CacheKeyTestCase(unittest.TestCase):
     @mock.patch('brainzutils.cache.redis.StrictRedis', autospec=True)
     def test_key_expire(self, mock_redis):
         cache.init(host='host', port=2, namespace=self.namespace)
-        cache.set('key', u'value'.encode('utf-8'), time=30)
+        cache.set('key', u'value'.encode('utf-8'), expirein=30)
         expected_key = 'NS_TEST:key'.encode('utf-8')
         # msgpack encoded value
         expected_value = b'\xc4\x05value'


### PR DESCRIPTION
BU-41
As of now, keys do not timeout by default . If the user forgets to specify an expiry time, it can lead to accumulation of non-expiring keys in redis which is undesirable. To avoid accumulating non-expiring keys in redis, we make the time parameter required. If the user wants to set a non-expiring key, they can do `expirein=0` explicitly.