### PR TITLE
BU-31: Upgrade raven -> sentry-python

### DIFF
--- a/brainzutils/flask/__init__.py
+++ b/brainzutils/flask/__init__.py
@@ -43,7 +43,6 @@ class CustomFlask(Flask):
 
     def init_loggers(self,
                      file_config=None,
-                     email_config=None,
                      sentry_config=None):
         """This method attaches loggers to the Flask app.
 
@@ -63,20 +62,6 @@ class CustomFlask(Flask):
                     'backup_count': 100,      # optional
                 }
 
-            email_config (dict): Dictionary with the following structure::
-
-                {
-                    'mail_server': 'localhost',
-                    'mail_port': 25,
-                    'mail_from_host': 'example.org',
-                    'log_email_recipients': [
-                        'user1@example.org',
-                        'user2@example.org',
-                    ],
-                    'log_email_topic': 'Error occurred',
-                    'level': 'ERROR',  # optional
-                }
-
             sentry_config (dict): Dictionary with the following structure::
 
                 {
@@ -86,7 +71,5 @@ class CustomFlask(Flask):
         """
         if file_config:
             loggers.add_file_handler(self, **file_config)
-        if email_config:
-            loggers.add_email_handler(self, **email_config)
         if sentry_config:
             loggers.add_sentry(self, **sentry_config)

--- a/brainzutils/flask/loggers.py
+++ b/brainzutils/flask/loggers.py
@@ -20,31 +20,6 @@ def add_file_handler(app, filename, max_bytes=512 * 1024, backup_count=100):
     app.logger.addHandler(file_handler)
 
 
-def add_email_handler(app, mail_server, mail_port, mail_from_host,
-                      log_email_recipients, log_email_topic,
-                      level=logging.ERROR):
-    """Adds email notifications about captured logs."""
-    mail_handler = SMTPHandler(
-        (mail_server, mail_port),
-        "logs@" + mail_from_host,
-        log_email_recipients,
-        log_email_topic
-    )
-    mail_handler.setLevel(level)
-    mail_handler.setFormatter(logging.Formatter('''
-    Message type: %(levelname)s
-    Location: %(pathname)s:%(lineno)d
-    Module: %(module)s
-    Function: %(funcName)s
-    Time: %(asctime)s
-
-    Message:
-
-    %(message)s
-    '''))
-    app.logger.addHandler(mail_handler)
-
-
 def add_sentry(app, dsn, level=logging.WARNING, **options):
     """Adds Sentry logging.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ Jinja2>=2.11.2
 werkzeug>=1.0.1
 Flask-DebugToolbar>=0.11.0
 Flask-UUID>=0.2
-raven[flask]>=6.10.0
+sentry-sdk[flask]>=0.20.2
 certifi
 redis>=3.5,<4.0
 msgpack-python==0.5.6


### PR DESCRIPTION
BU-31

`sentry_sdk` is the new sentry python SDK meant as a replacement for `raven`.

`sentry_sdk` does not provide a client to work with like `raven` instead we call `sentry_sdk.init` to configure Sentry. Hence, the `MissingRavenClient` functionality is no longer relevant. In case sentry logging is not configured, no messages, logs or events are captured and the application continues to work normally.

Another thing to consider is the "SENTRY_TRANSPORT" configuration is no longer set. I was unable to understand its purpose and find if there is an equivalent of this in `sentry_sdk`.

This update has been tested in the downstream projects (AB, CB, LB, MeB) and works well. Except the dependency upgrade, changes are only required in the downstream projects if they used raven directly. The `bu-sentrysdk-upgrade` project was created to test this upgrade and should be deleted from sentry.metabrainz.org once we are satisfied with the testing.