### PR TITLE
Add client name to redis configuration

### DIFF
--- a/brainzutils/cache.py
+++ b/brainzutils/cache.py
@@ -32,24 +32,26 @@ CONTENT_ENCODING = "utf-8"
 ENCODING_ASCII = "ascii"
 
 
-def init(host="localhost", port=6379, db_number=0, namespace="", client_name: Optional[str] = None):
+def init(host: str = "localhost", port: int = 6379, db_number: int = 0,
+         namespace: str = "", client_name: Optional[str] = None):
     """Initializes Redis client. Needs to be called before use.
 
     Namespace versions are stored in a local directory.
 
     Args:
-        host (str): Redis server hostname.
-        port (int): Redis port.
-        db_number (int): Redis database number.
-        namespace (str): Global namespace that will be prepended to all keys.
+        host: Redis server hostname.
+        port: Redis port.
+        db_number: Redis database number.
+        namespace: Global namespace that will be prepended to all keys.
         client_name: The client name to assign to the redis connection. usually
          only needs to be specified if at all during testing or development.
     """
 
-    # The first priority in setting the client name is to set the user specified client_name
-    # as this can come in handy during testing and development. Otherwise, we use CONTAINER_NAME
-    # environment variable, this is always set in production. Finally, we fall back to the host
-    # name, not as informative as the container name but something is better than nothing.
+    # The first priority in setting the client name is to set the user specified
+    # client_name as this can come in handy during testing and development. Otherwise,
+    # we use CONTAINER_NAME environment variable, this is always set in production.
+    # Finally, we fall back to the host name, not as informative as the container name
+    # but something is better than nothing.
     if client_name is None:
         client_name = os.getenv("CONTAINER_NAME", None)
     if client_name is None:

--- a/brainzutils/cache.py
+++ b/brainzutils/cache.py
@@ -33,7 +33,7 @@ ENCODING_ASCII = "ascii"
 
 
 def init(host: str = "localhost", port: int = 6379, db_number: int = 0,
-         namespace: str = "", client_name: Optional[str] = None):
+         namespace: str = "", client_name: str = None):
     """Initializes Redis client. Needs to be called before use.
 
     Namespace versions are stored in a local directory.

--- a/brainzutils/cache.py
+++ b/brainzutils/cache.py
@@ -43,8 +43,8 @@ def init(host: str = "localhost", port: int = 6379, db_number: int = 0,
         port: Redis port.
         db_number: Redis database number.
         namespace: Global namespace that will be prepended to all keys.
-        client_name: The client name to assign to the redis connection. usually
-         only needs to be specified if at all during testing or development.
+        client_name: The client name to assign to the redis connection. This value is used to identify which clients
+          are connected to a server, and is only used for debugging purposes.
     """
 
     # The first priority in setting the client name is to set the user specified


### PR DESCRIPTION
The client names show up in redis-cli and are more helpful in identifying a connection than docker gateway IP.