### PR TITLE
Set container name as sentry tag

### DIFF
--- a/brainzutils/flask/loggers.py
+++ b/brainzutils/flask/loggers.py
@@ -36,6 +36,7 @@ def add_sentry(dsn, level=logging.WARNING, **options):
     sentry_sdk.init(dsn, integrations=[LoggingIntegration(level=level), FlaskIntegration(), RedisIntegration(),
                                        SqlalchemyIntegration()],
                     **options)
+    # This env variable is set in the MetaBrainz production infrastructure and is unique per container
     container_name = os.getenv("CONTAINER_NAME")
     if container_name:
         sentry_sdk.set_tag("container_name", container_name)

--- a/brainzutils/flask/loggers.py
+++ b/brainzutils/flask/loggers.py
@@ -1,5 +1,6 @@
 # pylint: disable=invalid-name
 import logging
+import os
 from logging.handlers import RotatingFileHandler, SMTPHandler
 
 import sentry_sdk
@@ -35,3 +36,6 @@ def add_sentry(dsn, level=logging.WARNING, **options):
     sentry_sdk.init(dsn, integrations=[LoggingIntegration(level=level), FlaskIntegration(), RedisIntegration(),
                                        SqlalchemyIntegration()],
                     **options)
+    container_name = os.getenv("CONTAINER_NAME")
+    if container_name:
+        sentry_sdk.set_tag("container_name", container_name)


### PR DESCRIPTION
Useful in identifying in which container an error occured.