### PR TITLE
Remove flask-specific logging methods

### DIFF
--- a/brainzutils/flask/__init__.py
+++ b/brainzutils/flask/__init__.py
@@ -1,7 +1,6 @@
 from flask import Flask
 from flask_uuid import FlaskUUID
 from flask_debugtoolbar import DebugToolbarExtension
-from brainzutils.flask import loggers
 
 
 class CustomFlask(Flask):
@@ -29,7 +28,6 @@ class CustomFlask(Flask):
         if use_flask_uuid:
             FlaskUUID(self)
 
-
     def init_debug_toolbar(self):
         """This method initializes the Flask-Debug extension toolbar for the
         Flask app.
@@ -39,38 +37,3 @@ class CustomFlask(Flask):
         """
         if self.debug:
             DebugToolbarExtension(self)
-
-
-    def init_loggers(self,
-                     file_config=None,
-                     sentry_config=None):
-        """This method attaches loggers to the Flask app.
-
-        Each type of logger has its own configuration which needs to be passed
-        as an argument to this method. If you don't want to enable one of
-        available loggers, set its configuration to None.
-
-        Logging levels (when specified) need to be one of supported by
-        `logging` module, as an integer or a valid string.
-
-        Args:
-            file_config (dict): Dictionary with the following structure::
-
-                {
-                    'filename': 'log.txt',
-                    'max_bytes': 512 * 1024,  # optional
-                    'backup_count': 100,      # optional
-                }
-
-            sentry_config (dict): Dictionary with the following structure::
-
-                {
-                    'dsn': 'YOUR_SENTRY_DSN',
-                    'environment': 'production',  # optional
-                    'level': 'WARNING',  # optional
-                }
-        """
-        if file_config:
-            loggers.add_file_handler(self, **file_config)
-        if sentry_config:
-            loggers.add_sentry(**sentry_config)

--- a/brainzutils/sentry.py
+++ b/brainzutils/sentry.py
@@ -1,7 +1,5 @@
-# pylint: disable=invalid-name
 import logging
 import os
-from logging.handlers import RotatingFileHandler, SMTPHandler
 
 import sentry_sdk
 from sentry_sdk.integrations.sqlalchemy import SqlalchemyIntegration
@@ -10,22 +8,11 @@ from sentry_sdk.integrations.redis import RedisIntegration
 from sentry_sdk.integrations.flask import FlaskIntegration
 
 
-def add_file_handler(app, filename, max_bytes=512 * 1024, backup_count=100):
-    """Adds file logging."""
-    file_handler = RotatingFileHandler(filename, maxBytes=max_bytes,
-                                       backupCount=backup_count)
-    file_handler.setFormatter(logging.Formatter(
-        '%(asctime)s %(levelname)s: %(message)s '
-        '[in %(pathname)s:%(lineno)d]'
-    ))
-    app.logger.addHandler(file_handler)
-
-
-def add_sentry(dsn, level=logging.WARNING, **options):
+def init_sentry(dsn, level=logging.WARNING, **options):
     """Adds Sentry event logging.
 
     Sentry is a realtime event logging and aggregation platform.
-    By default we add integration to the python logger, flask, redis, and sqlalchemy.
+    By default, we add integration to the python logger, flask, redis, and sqlalchemy.
 
     Arguments:
         dsn: The sentry DSN to connect to


### PR DESCRIPTION
We don't use the brainzutils-specific file logger in any downstream apps, so remove it (like we removed the email logger)

When we used raven for sentry setup, we needed a flask app instance, but now with sentry_sdk it's not required. This means it makes more sense to configure flask as a brainzutils method, rather than as a method on the flask app itself, so move this to 

This is a backwards-incompatible change with all downstream apps, we'll have to reconfigure the way that we configure sentry. If we want to make it backwards compatible for a few releases we could add a shim back in to `CustomFlask.init_loggers`