### PR TITLE
Pin itsdangerous dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ mbdata==25.0.4
 sqlalchemy-dst>=1.0.1
 importlib-metadata>=3.10.0
 itsdangerous==2.0.1  # last version compatible with Flask 1.*
+MarkupSafe==2.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Flask>=1.1.2,<2
+Flask>=1.1.2
 Jinja2>=2.11.2
 werkzeug>=1.0.1
 Flask-DebugToolbar>=0.11.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,5 +12,6 @@ SQLAlchemy>=1.3.16
 mbdata==25.0.4
 sqlalchemy-dst>=1.0.1
 importlib-metadata>=3.10.0
-itsdangerous==2.0.1  # last version compatible with Flask 1.*
+# last versions compatible with Flask 1.*
+itsdangerous==2.0.1
 MarkupSafe==2.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ SQLAlchemy>=1.3.16
 mbdata==25.0.4
 sqlalchemy-dst>=1.0.1
 importlib-metadata>=3.10.0
+itsdangerous==2.0.1  # last version compatible with Flask 1.*

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Flask>=1.1.2
+Flask>=1.1.2,<2
 Jinja2>=2.11.2
 werkzeug>=1.0.1
 Flask-DebugToolbar>=0.11.0


### PR DESCRIPTION
itsdangerous 2.1.0 and onwards are incompatible with Flask 1.* so pin 2.0.1 the last compatible version.