### PR TITLE
Fix requirements.txt file

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,5 @@ SQLAlchemy>=1.3.16
 mbdata==25.0.4
 sqlalchemy-dst>=1.0.1
 importlib-metadata>=3.10.0
-# last versions compatible with Flask 1.*
 itsdangerous==2.0.1
 MarkupSafe==2.0.1


### PR DESCRIPTION
In setup.py we prepare install_requires list by reading requirements.txt and treating each line as a dependency. Adding comments on a separate line or leaving empty line thus creates issues when trying to install BU as a package. Remove empty line and comments to fix.