### PR TITLE
Update MB test database to SCHEMA_VERSION 26

### DIFF
--- a/brainzutils/musicbrainz_db/tests/test_artist.py
+++ b/brainzutils/musicbrainz_db/tests/test_artist.py
@@ -14,7 +14,7 @@ class TestArtist:
             "sort_name": "Linkin Park",
             "comment": "American rock band",
             "life-span": {"begin": "1999"},
-            "rating": 86,
+            "rating": 85,
             "type": "Group",
         }
 
@@ -25,7 +25,7 @@ class TestArtist:
             "mbid": "79239441-bfd5-4981-a70c-55c3f15c1287",
             "name": "Madonna",
             "sort_name": "Madonna",
-            "comment": "American singer-songwriter, actress, businesswoman, “Queen of Pop”",
+            "comment": "“Queen of Pop”",
             "life-span": {"begin": "1958-08-16"},
             "rating": 88,
             "type": "Person",
@@ -52,7 +52,7 @@ class TestArtist:
             "type": "Group",
             "comment": "American rock band",
             "life-span": {"begin": "1999"},
-            "rating": 86,
+            "rating": 85,
         }
 
     def test_fetch_multiple_artists_redirect(self, engine):
@@ -65,7 +65,7 @@ class TestArtist:
             "sort_name": "Linkin Park",
             "comment": "American rock band",
             "life-span": {"begin": "1999"},
-            "rating": 86,
+            "rating": 85,
             "type": "Group"
         }
 

--- a/brainzutils/musicbrainz_db/tests/test_label.py
+++ b/brainzutils/musicbrainz_db/tests/test_label.py
@@ -13,7 +13,7 @@ class TestLabel:
             "name": "Roc‐A‐Fella Records",
             "type": "Original Production",
             "area": "United States",
-            "life-span": {"begin": "1996"},
+            "life-span": {"begin": "1996", "end": "2013"},
             "rating": 100,
         }
 
@@ -48,7 +48,7 @@ class TestLabel:
             "name": "Roc‐A‐Fella Records",
             "type": "Original Production",
             "area": "United States",
-            "life-span": {"begin": "1996"},
+            "life-span": {"begin": "1996", "end": "2013"},
             "rating": 100
         }
 

--- a/brainzutils/musicbrainz_db/tests/test_place.py
+++ b/brainzutils/musicbrainz_db/tests/test_place.py
@@ -36,7 +36,7 @@ class TestPlace:
             ['4352063b-a833-421b-a420-e7fb295dece0', '2056ad56-cea9-4536-9f2d-58765a38829c']
         )
         assert places['4352063b-a833-421b-a420-e7fb295dece0']['name'] == 'Royal Albert Hall'
-        assert places['2056ad56-cea9-4536-9f2d-58765a38829c']['name'] == 'Finnvox Studios'
+        assert places['2056ad56-cea9-4536-9f2d-58765a38829c']['name'] == 'Finnvox'
 
     def test_fetch_multiple_places_redirect(self, engine):
         places = mb_place.fetch_multiple_places(

--- a/brainzutils/musicbrainz_db/tests/test_recording.py
+++ b/brainzutils/musicbrainz_db/tests/test_recording.py
@@ -8,6 +8,7 @@ class TestRecording:
 
     def test_get_recording_by_mbid(self, engine):
         """ Tests if appropriate recording is returned for a given MBID. """
+        self.maxDiff = None
         recording = mb_recording.get_recording_by_mbid('daccb724-8023-432a-854c-e0accb6c8678', includes=['artists'])
 
         assert recording == {
@@ -16,13 +17,13 @@ class TestRecording:
             'comment': 'explicit',
             'length': 205.28,
             'rating': 78,
-            'artist-credit-phrase': 'Jay-Z / Linkin Park',
+            'artist-credit-phrase': 'Jay‐Z / Linkin Park',
             'artists': [
                 {
                     'mbid': 'f82bcf78-5b69-4622-a5ef-73800768d9ac',
                     'name': 'JAY‐Z',
-                    'credited_name': 'Jay-Z',
-                    'join_phrase': ' / '
+                    'credited_name': 'Jay‐Z',
+                    'join_phrase': ' / ',
                 },
                 {
                     'mbid': 'f59c5520-5f46-4d2c-b2c4-822eabf53419',
@@ -42,6 +43,7 @@ class TestRecording:
 
     def test_fetch_multiple_recordings(self, engine):
         """ Tests if appropriate recordings are returned for a given list of MBIDs. """
+        self.maxDiff = None
 
         mbids = ['daccb724-8023-432a-854c-e0accb6c8678', 'ae83579c-5f33-4a35-83f3-89206c44a426']
         recordings = mb_recording.fetch_multiple_recordings(mbids, includes=['artists'])
@@ -53,13 +55,13 @@ class TestRecording:
                 'comment': 'explicit',
                 'length': 205.28,
                 'rating': 78,
-                'artist-credit-phrase': 'Jay-Z / Linkin Park',
+                'artist-credit-phrase': 'Jay‐Z / Linkin Park',
                 'artists': [
                     {
                         'mbid': 'f82bcf78-5b69-4622-a5ef-73800768d9ac',
                         'name': 'JAY‐Z',
-                        'credited_name': 'Jay-Z',
-                        'join_phrase': ' / '
+                        'credited_name': 'Jay‐Z',
+                        'join_phrase': ' / ',
                     },
                     {
                         'mbid': 'f59c5520-5f46-4d2c-b2c4-822eabf53419',

--- a/brainzutils/musicbrainz_db/tests/test_release.py
+++ b/brainzutils/musicbrainz_db/tests/test_release.py
@@ -127,7 +127,7 @@ class TestRelease:
                 'position': 6,
                 'length': 339866,
                 'recording_id': '2d9a5b40-f5e6-4499-ab7a-567fe3b42ab9',
-                 'recording_title': 'Leper Messiah',
+                'recording_title': 'Leper Messiah',
                 'artist-credit': [
                     {
                         'name': 'Metallica',
@@ -222,21 +222,27 @@ class TestRelease:
 
     def test_get_releases_using_recording_mbid(self, engine):
         """Tests if releases are fetched correctly for a given recording MBID"""
+        self.maxDiff = None
+
         releases = mb_release.get_releases_using_recording_mbid('5465ca86-3881-4349-81b2-6efbd3a59451')
+
         assert releases == [
-            {'mbid': '89f64145-2f75-41d1-831a-517b785ed75a', 'name': "The Blueprint Collector's Edition"},
+            {'mbid': 'cb48685f-beea-4ca6-93f3-49ef4d8cbf28', 'name': 'The Blueprint²: The Gift & The Curse'},
+            {'mbid': '4c9bd72b-dae9-44bf-a052-9b2f6c0d50de', 'name': 'Back to Bey-Sic', 'comment': 'deluxe edition'},
+            {'mbid': '89f64145-2f75-41d1-831a-517b785ed75a', 'name': 'The Blueprint Collector’s Edition'},
             {'mbid': 'f1183a86-36d2-4f1f-ab8f-6f965dc0b033', 'name': 'The Hits Collection Volume One'},
+            {'mbid': '7c77ca4d-d84b-4b67-8705-e6afe9eb5878', 'name': 'The Blueprint²: The Gift & The Curse', 'comment': 'MQA, explicit'},
             {'mbid': '77a74b85-0ae0-338f-aaca-4f36cd394f88', 'name': 'Blueprint 2.1'},
+            {'mbid': 'cb180855-979d-4d5d-9024-3bc97c64d19c', 'name': 'The Blueprint²: The Gift & The Curse', 'comment': 'explicit'},
+            {'mbid': 'b207b569-6323-4426-801b-3d5dbaf28d49', 'name': 'The Blueprint²: The Gift & The Curse', 'comment': 'explicit'},
             {'mbid': '7111c8bc-8549-4abc-8ab9-db13f65b4a55', 'name': 'Blueprint 2.1'},
-            {'mbid': '2c5e4198-24cf-3c95-a16e-83be8e877dfa', 'name': 'The Blueprint²: The Gift & The Curse', 'comment': 'clean/edited'},
             {'mbid': '3c535d03-2fcc-467a-8d47-34b3250b8211', 'name': 'The Hits Collection Volume One', 'comment': 'explicit'},
             {'mbid': 'c84d8fa8-6f8d-42c9-87cc-b726e859b41d', 'name': 'The Hits Collection Volume One', 'comment': 'edited version'},
+            {'mbid': '8d51f750-7ee9-4937-8907-0243efc2f6df', 'name': 'The Blueprint²: The Gift & The Curse', 'comment': 'explicit'},
             {'mbid': '4f41108c-db36-4616-8614-f504fdef287a', 'name': 'Blueprint 2.1'},
             {'mbid': 'b0075ce9-58c8-47e2-8a72-5f783314a97e', 'name': 'The Hits Collection Volume One', 'comment': 'explicit'},
-            {'mbid': 'd75e103c-5ef4-4146-ae81-e27d19dc7fc4', 'name': "The Blueprint Collector's Edition"},
             {'mbid': '4a441628-2e4d-4032-825f-6bdf4aee382e', 'name': 'The Hits Collection, Volume 1'},
             {'mbid': '5e782ae3-602b-48b7-99be-de6bcffa4aba', 'name': 'The Hits Collection, Volume 1', 'comment': 'Deluxe edition'},
             {'mbid': '7ebaaa95-e316-3b20-8819-7e4ca648c135', 'name': 'The Hits Collection, Volume 1'},
-            {'mbid': '0ff452e3-c306-4082-b0dc-223725f4fbbf', 'name': 'The Blueprint²: The Gift & The Curse'},
-            {'mbid': '801678aa-5d30-4342-8227-e9618f164cca', 'name': 'The Blueprint²: The Gift & The Curse'}
+            {'mbid': '240f52cd-9120-452d-98de-8df087e389e8', 'name': 'The Real Best of Both Worlds'}
         ]

--- a/brainzutils/musicbrainz_db/tests/test_work.py
+++ b/brainzutils/musicbrainz_db/tests/test_work.py
@@ -26,7 +26,7 @@ class TestWork:
             includes=['artist-rels', 'recording-rels'])
         assert work["mbid"] == "36e33f94-ef5f-36b5-97b0-c1ed9c5a542f"
         assert len(work["artist-rels"]) == 4
-        assert len(work["recording-rels"]) == 51
+        assert len(work["recording-rels"]) == 55
 
     def test_fetch_multiple_works(self, engine):
         works = mb_work.fetch_multiple_works([

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -17,7 +17,7 @@ services:
     image: redis:3.2.1
 
   musicbrainz_db:
-    image: metabrainz/brainzutils-mb-sample-database:schema-25-2021-04-04.0
+    image: metabrainz/brainzutils-mb-sample-database:schema-26-2022-05-10.0
     environment:
       POSTGRES_HOST_AUTH_METHOD: trust
     ports:


### PR DESCRIPTION
We used schema version 25 till now but 26 is the current latest so makes sense to use that.