### PR TITLE
Upgrade tests to use schema 27 test database

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ redis>=3.5,<4.0
 msgpack==0.5.6
 requests>=2.23.0
 SQLAlchemy>=1.3.16
-mbdata==25.0.4
+git+https://github.com/amCap1712/mbdata.git@upstream-schema-changes#egg=mbdata
 sqlalchemy-dst>=1.0.1
 importlib-metadata>=3.10.0
 itsdangerous==2.0.1

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -17,7 +17,7 @@ services:
     image: redis:3.2.1
 
   musicbrainz_db:
-    image: metabrainz/brainzutils-mb-sample-database:schema-26-2022-05-10.0
+    image: metabrainz/brainzutils-mb-sample-database:schema-27-2022-05-20.0
     environment:
       POSTGRES_HOST_AUTH_METHOD: trust
     ports:


### PR DESCRIPTION
Currently using the git checkout of mbdata.

Schema changes are currently causing errors on [event pages on CB](https://critiquebrainz.org/event/d5910c09-b98b-4806-a56c-ea1f06951179), so I think that we should merge this with the git branch, and then update again when mbdata 27 is released