### PR TITLE
Use PEP508-style requirements, supported by both pip and install_requires

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ redis>=3.5,<4.0
 msgpack==0.5.6
 requests>=2.23.0
 SQLAlchemy>=1.3.16
-git+https://github.com/amCap1712/mbdata.git@upstream-schema-changes#egg=mbdata
+mbdata@git+https://github.com/amCap1712/mbdata.git@upstream-schema-changes
 sqlalchemy-dst>=1.0.1
 importlib-metadata>=3.10.0
 itsdangerous==2.0.1


### PR DESCRIPTION
The `git+https://github.com/amCap1712/mbdata.git@upstream-schema-changes#egg=mbdata` syntax isn't supported when this value is in `install_requires` in setup.py.
This caused problems when another project imported BU as a dependency, resulting in a failure to clone the mbdata fork that we're currently using for schema 27.
recent pip also supports installing from a [PEP-058](https://peps.python.org/pep-0508/) specification, so just switch to that in requrements.txt. This is copied into setup.py and works fine when installing  transitive dependencies.