### PR TITLE
msgpack-python is now maintained as msgpack

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ Flask-UUID>=0.2
 sentry-sdk[flask]>=1.5.8
 certifi
 redis>=4.2.2
-msgpack-python==0.5.6
+msgpack==0.5.6
 requests>=2.27.1
 SQLAlchemy>=1.3.16,<2.0
 mbdata@git+https://github.com/amCap1712/mbdata.git@upstream-schema-changes


### PR DESCRIPTION
See #90. This change got reverted while merging another PR.