### PR TITLE
Enable sqlalchemy warnings and update mbdata

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,6 @@
 [pytest]
 testpaths = brainzutils
-addopts = --cov-report html --cov=brainzutils
+addopts = --cov-report html --cov=brainzutils -W always::DeprecationWarning
 
 markers =
     database: requires access to the musicbrainz sample database

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,6 @@ redis>=4.2.2
 msgpack==0.5.6
 requests>=2.27.1
 SQLAlchemy>=1.3.16,<2.0
-mbdata@git+https://github.com/amCap1712/mbdata.git@upstream-schema-changes
+mbdata@git+https://github.com/amCap1712/mbdata.git@fix-sqlalchemy-warnings
 sqlalchemy-dst>=1.0.1
 importlib-metadata>=3.10.0;python_version<'3.10'

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -9,6 +9,7 @@ services:
       - ../:/code
     environment:
       PYTHONDONTWRITEBYTECODE: 1
+      SQLALCHEMY_WARN_20: 1
     depends_on:
       - redis
       - musicbrainz_db


### PR DESCRIPTION
With SQLAlchemy warnings enabled, SQLAlchemy 1.4 gives the following warning.

MovedIn20Warning: The declarative_base() function is now available as sqlalchemy.orm.declarative_base(). (deprecated since: 1.4) (Background on SQLAlchemy 2.0 at: https://sqlalche.me/e/b8d9) Base = declarative_base()

The rationale of the move is explained here: https://docs.sqlalchemy.org/en/14/changelog/migration_20.html#declarative-becomes-a-first-class-api

This is fixed in mbdata in https://github.com/acoustid/mbdata/pull/52, meanwhile BU is using our fork anyway so we can update. There are some other warnings in BU code that result in SQLAlchemy warnings but not fixing those for now as those are only relevant to CB, will fix those separately.