### PR TITLE
Join relationships using attributes, not strings

### DIFF
--- a/brainzutils/musicbrainz_db/artist.py
+++ b/brainzutils/musicbrainz_db/artist.py
@@ -44,7 +44,7 @@ def fetch_multiple_artists(mbids, includes=None):
     check_includes('artist', includes)
 
     with mb_session() as db:
-        query = db.query(models.Artist).options(joinedload('type'))
+        query = db.query(models.Artist).options(joinedload(models.Artist.type))
 
         artists = get_entities_by_gids(
             query=query,

--- a/brainzutils/musicbrainz_db/event.py
+++ b/brainzutils/musicbrainz_db/event.py
@@ -73,7 +73,7 @@ def fetch_multiple_events(mbids, includes=None):
     includes_data = defaultdict(dict)
     check_includes('event', includes)
     with mb_session() as db:
-        query = db.query(models.Event).options(joinedload('type'))
+        query = db.query(models.Event).options(joinedload(models.Event.type))
         events = get_entities_by_gids(
             query=query,
             entity_type='event',

--- a/brainzutils/musicbrainz_db/label.py
+++ b/brainzutils/musicbrainz_db/label.py
@@ -43,8 +43,8 @@ def fetch_multiple_labels(mbids, includes=None):
     check_includes('label', includes)
     with mb_session() as db:
         query = db.query(models.Label).\
-            options(joinedload("type")).\
-            options(joinedload("area"))
+            options(joinedload(models.Label.type)).\
+            options(joinedload(models.Label.area))
         labels = get_entities_by_gids(
             query=query,
             entity_type='label',

--- a/brainzutils/musicbrainz_db/place.py
+++ b/brainzutils/musicbrainz_db/place.py
@@ -44,8 +44,8 @@ def fetch_multiple_places(mbids, includes=None):
     check_includes('place', includes)
     with mb_session() as db:
         query = db.query(models.Place).\
-            options(joinedload("area")).\
-            options(joinedload("type"))
+            options(joinedload(models.Place.area)).\
+            options(joinedload(models.Place.type))
         places = get_entities_by_gids(
             query=query,
             entity_type='place',

--- a/brainzutils/musicbrainz_db/work.py
+++ b/brainzutils/musicbrainz_db/work.py
@@ -43,7 +43,7 @@ def fetch_multiple_works(mbids, includes=None):
     includes_data = defaultdict(dict)
     check_includes('work', includes)
     with mb_session() as db:
-        query = db.query(models.Work).options(joinedload("type"))
+        query = db.query(models.Work).options(joinedload(models.Work.type))
 
         works = get_entities_by_gids(
             query=query,

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,6 @@
 [pytest]
 testpaths = brainzutils
-addopts = --cov-report html --cov=brainzutils -W always::DeprecationWarning
+addopts = --cov-report html --cov=brainzutils -W always::DeprecationWarning -W error::sqlalchemy.exc.Base20DeprecationWarning
 
 markers =
     database: requires access to the musicbrainz sample database


### PR DESCRIPTION
This commit fixes the warning:

RemovedIn20Warning: Using strings to indicate column or relationship paths in loader options is deprecated and will be removed in SQLAlchemy 2.0.  Please use the class-bound attribute directly. (Background on SQLAlchemy 2.0 at: https://sqlalche.me/e/b8d9)

For rationale, see section: https://docs.sqlalchemy.org/en/14/changelog/migration_20.html#orm-query-joining-loading-on-relationships-uses-attributes-not-strings