### PR TITLE
Fix loading artist incs for releases

### DIFF
--- a/brainzutils/musicbrainz_db/release.py
+++ b/brainzutils/musicbrainz_db/release.py
@@ -49,7 +49,7 @@ def fetch_multiple_releases(mbids, includes=None):
             query = query.options(joinedload(Release.release_group))
         if 'artists' in includes:
             query = query.options(
-                joinedload(Recording.artist_credit).
+                joinedload(Release.artist_credit).
                 joinedload(ArtistCredit.artists).
                 joinedload(ArtistCreditName.artist)
             )


### PR DESCRIPTION
I introduced this bug in #96. Fix by using the correct entity in joinedload.