### PR TITLE
Add read the docs config

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,15 @@
+version: 2
+
+build:
+  os: ubuntu-20.04
+  tools:
+    python: "3.10"
+
+sphinx:
+   configuration: docs/conf.py
+
+formats: all
+
+python:
+   install:
+   - requirements: docs/requirements.txt


### PR DESCRIPTION
Adding the missing config file soon required by read the docs:

  https://blog.readthedocs.com/migrate-configuration-v2/